### PR TITLE
Use a static instance of HttpClient to limit open files during tests.

### DIFF
--- a/src/main/java/com/apicatalog/jsonld/api/JsonLdOptions.java
+++ b/src/main/java/com/apicatalog/jsonld/api/JsonLdOptions.java
@@ -78,14 +78,18 @@ public final class JsonLdOptions {
     private Boolean omitGraph;
     
     private boolean requiredAll;
-    
+
     public JsonLdOptions() {
+        this(new HttpLoader());
+    }
+    
+    public JsonLdOptions(HttpLoader httpLoader) {
         
         // default values
         this.base = null;
         this.compactArrays = true;
         this.compactToRelative = true;
-        this.documentLoader = new HttpLoader();
+        this.documentLoader = httpLoader;
         this.expandContext = null;
         this.extractAllScripts = false;
         this.ordered = false;

--- a/src/test/java/com/apicatalog/jsonld/RemoteTest.java
+++ b/src/test/java/com/apicatalog/jsonld/RemoteTest.java
@@ -2,6 +2,7 @@ package com.apicatalog.jsonld;
 
 import static org.junit.Assume.assumeFalse;
 
+import java.net.http.HttpClient;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -40,9 +41,9 @@ public class RemoteTest {
     
     @Rule
     public final WireMockRule wireMockRule = new WireMockRule();
-    
-    public static final HttpLoader HTTP_LOADER = new HttpLoader();
-    
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NEVER).build();
+
     @Test
     public void testRemote() {
 
@@ -62,8 +63,8 @@ public class RemoteTest {
                 expandOptions.setDocumentLoader(
                                     new UriBaseRewriter(
                                                 TESTS_BASE, 
-                                                wireMockRule.baseUrl(), 
-                                                HTTP_LOADER));
+                                                wireMockRule.baseUrl(),
+                                                new HttpLoader(HTTP_CLIENT, HttpLoader.MAX_REDIRECTIONS)));
                 
                 return JsonLd.expand(testCase.input).options(expandOptions).get();
             });

--- a/src/test/java/com/apicatalog/jsonld/suite/JsonLdTestCase.java
+++ b/src/test/java/com/apicatalog/jsonld/suite/JsonLdTestCase.java
@@ -1,6 +1,7 @@
 package com.apicatalog.jsonld.suite;
 
 import java.net.URI;
+import java.net.http.HttpClient;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -14,11 +15,14 @@ import com.apicatalog.jsonld.api.JsonLdOptions;
 import com.apicatalog.jsonld.http.media.MediaType;
 import com.apicatalog.jsonld.json.JsonUtils;
 import com.apicatalog.jsonld.lang.Keywords;
+import com.apicatalog.jsonld.loader.HttpLoader;
 import com.apicatalog.jsonld.loader.LoadDocumentCallback;
 import com.apicatalog.jsonld.suite.loader.UriBaseRewriter;
 import com.apicatalog.jsonld.suite.loader.ZipResourceLoader;
 
 public final class JsonLdTestCase {
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NEVER).build();
 
     public String id;
     
@@ -55,7 +59,7 @@ public final class JsonLdTestCase {
     public JsonLdTestCase(final String testsBase) {
         this.testsBase = testsBase;
     }
-    
+
     public static final JsonLdTestCase of(JsonObject o, String manifestUri, String manifestBase, String baseUri) {
         
         final JsonLdTestCase testCase = new JsonLdTestCase(manifestBase);
@@ -151,7 +155,7 @@ public final class JsonLdTestCase {
                             new ZipResourceLoader(true)
                         );
         
-        JsonLdOptions jsonLdOptions = new JsonLdOptions();
+        JsonLdOptions jsonLdOptions = new JsonLdOptions(new HttpLoader(HTTP_CLIENT, HttpLoader.MAX_REDIRECTIONS));
         jsonLdOptions.setOrdered(true);
         jsonLdOptions.setDocumentLoader(loader);
         


### PR DESCRIPTION
I made some changes -- I see you made some too. The following works for me. Using the latest 'v0.7.4' branch I still got the exception. Using the default JsonLdOptions() constructor invoked ```new HttpLoader()```, which seemed to be at least a partial cause of the problem. 