### PR TITLE
Forced Locale to avoid wrong toRdf Literal number formatting

### DIFF
--- a/src/main/java/com/apicatalog/jsonld/deseralization/ObjectToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/ObjectToRdf.java
@@ -17,7 +17,9 @@ package com.apicatalog.jsonld.deseralization;
 
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.List;
+import java.util.Locale;
 
 import javax.json.JsonNumber;
 import javax.json.JsonObject;
@@ -271,14 +273,15 @@ final class ObjectToRdf {
         // 15.
         return rdfLiteral;
     }
+
+    private static final DecimalFormat eFormat =
+            new DecimalFormat("0.0##############E0", new DecimalFormatSymbols(Locale.ENGLISH));
+
+    static { eFormat.setMinimumFractionDigits(1); }
     
     private static final String toXsdDouble(BigDecimal bigDecimal) {
         
-        if (bigDecimal.compareTo(BigDecimal.ZERO) == 0) {
-            return "0.0E0";
-        }
-        
-        return new DecimalFormat("0.0##############E0").format(bigDecimal);        
+        return eFormat.format(bigDecimal);        
     }
     
 }

--- a/src/main/java/com/apicatalog/jsonld/deseralization/ObjectToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/ObjectToRdf.java
@@ -53,6 +53,11 @@ import com.apicatalog.rdf.lang.XsdConstants;
  */
 final class ObjectToRdf {
 
+    private static final DecimalFormat eFormat =
+            new DecimalFormat("0.0##############E0", new DecimalFormatSymbols(Locale.ENGLISH));
+
+    static { eFormat.setMinimumFractionDigits(1); }
+
     // required
     private JsonObject item;
     private List<RdfTriple> triples;
@@ -273,11 +278,6 @@ final class ObjectToRdf {
         // 15.
         return rdfLiteral;
     }
-
-    private static final DecimalFormat eFormat =
-            new DecimalFormat("0.0##############E0", new DecimalFormatSymbols(Locale.ENGLISH));
-
-    static { eFormat.setMinimumFractionDigits(1); }
     
     private static final String toXsdDouble(BigDecimal bigDecimal) {
         

--- a/src/main/java/com/apicatalog/jsonld/json/JsonCanonicalizer.java
+++ b/src/main/java/com/apicatalog/jsonld/json/JsonCanonicalizer.java
@@ -20,6 +20,8 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import javax.json.JsonArray;
@@ -81,6 +83,12 @@ public final class JsonCanonicalizer {
         }
     }
 
+    private static final DecimalFormat eFormatBigDecimal =
+            new DecimalFormat("0E00", new DecimalFormatSymbols(Locale.ENGLISH));
+
+    private static final DecimalFormat eFormat =
+            new DecimalFormat("0.#######", new DecimalFormatSymbols(Locale.ENGLISH));
+
     private static final void canonicalizeNumber(final JsonNumber number, final Writer writer) throws IOException {
         
         String numberString;
@@ -91,15 +99,15 @@ public final class JsonCanonicalizer {
         
         } else if (number.bigDecimalValue().compareTo(BigDecimal.ONE.movePointRight(21)) >= 0) {
             
-            numberString = (new DecimalFormat("0E00")).format(number.bigDecimalValue()).replace("E", "e+");
+            numberString = eFormatBigDecimal.format(number.bigDecimalValue()).replace("E", "e+");
             
         } else if (number.bigDecimalValue().compareTo(BigDecimal.ONE.movePointLeft(21)) <= 0) {
             
-            numberString = (new DecimalFormat("0E00")).format(number.bigDecimalValue()).toLowerCase();
+            numberString = eFormatBigDecimal.format(number.bigDecimalValue()).toLowerCase();
             
         } else {
-            
-            numberString = (new DecimalFormat("0.#######")).format(number.bigDecimalValue());
+
+            numberString = eFormat.format(number.bigDecimalValue());
         }
         
         writer.write(numberString);        

--- a/src/main/java/com/apicatalog/jsonld/json/JsonCanonicalizer.java
+++ b/src/main/java/com/apicatalog/jsonld/json/JsonCanonicalizer.java
@@ -38,6 +38,12 @@ import com.apicatalog.rdf.io.nquad.NQuadsWriter;
  */
 public final class JsonCanonicalizer {
 
+    private static final DecimalFormat eFormatBigDecimal =
+            new DecimalFormat("0E00", new DecimalFormatSymbols(Locale.ENGLISH));
+
+    private static final DecimalFormat eFormat =
+            new DecimalFormat("0.#######", new DecimalFormatSymbols(Locale.ENGLISH));
+
     private JsonCanonicalizer() {
     }
     
@@ -82,12 +88,6 @@ public final class JsonCanonicalizer {
             
         }
     }
-
-    private static final DecimalFormat eFormatBigDecimal =
-            new DecimalFormat("0E00", new DecimalFormatSymbols(Locale.ENGLISH));
-
-    private static final DecimalFormat eFormat =
-            new DecimalFormat("0.#######", new DecimalFormatSymbols(Locale.ENGLISH));
 
     private static final void canonicalizeNumber(final JsonNumber number, final Writer writer) throws IOException {
         

--- a/src/test/java/com/apicatalog/jsonld/JsonLdToRdfTest.java
+++ b/src/test/java/com/apicatalog/jsonld/JsonLdToRdfTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assume.assumeFalse;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
@@ -50,6 +51,8 @@ public class JsonLdToRdfTest {
     
     @Test
     public void testToRdf() throws IOException {
+        // Force a locale to something different than US to be aware of DecimalFormat errors
+        Locale.setDefault(Locale.FRANCE);
 
         // skip specVersion == 1.0
         assumeFalse(Version.V1_0.equals(testCase.options.specVersion));


### PR DESCRIPTION
Fixes https://github.com/filip26/titanium-json-ld/issues/66
Double or BigDecimal values are printed with commas instead of dots when using some other `Locale`. Force it.