### PR TITLE
Corrected recursion trigger for graph names.

### DIFF
--- a/src/main/java/com/apicatalog/jsonld/framing/Framing.java
+++ b/src/main/java/com/apicatalog/jsonld/framing/Framing.java
@@ -154,7 +154,7 @@ public final class Framing {
                     
                 // 4.5.2.
                 } else {
-                    recurse = !Keywords.ID.equals(id) && !Keywords.DEFAULT.equals(id);
+                    recurse = !Keywords.MERGED.equals(id) && !Keywords.DEFAULT.equals(id);
                     
                     if (JsonUtils.isObject(frame.get(Keywords.GRAPH))
                             || JsonUtils.isArray(frame.get(Keywords.GRAPH))


### PR DESCRIPTION
Step 4.5.2 of the Framing Algorithm states:

Otherwise, set subframe to the first entry for @graph in frame, or a new empty map, if it does not exist, and set recurse to true, unless id is @merged or @default.


The code checked for "@id" or "@default". I have corrected this.