### PR TITLE
Fix Context Processing Algorithm 5.2.4

### DIFF
--- a/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
+++ b/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
@@ -27,6 +27,7 @@ import com.apicatalog.jsonld.loader.SchemeRouter;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 
 /**
  * The {@link JsonLdOptions} type is used to pass various options to the processor.
@@ -107,7 +108,7 @@ public final class JsonLdOptions {
     private boolean numericId;
 
     // context cache
-    private Cache<String, ActiveContext> contextCache;
+    private Cache<String, JsonValue> contextCache;
 
     // document cache
     private Cache<String, Document> documentCache;
@@ -407,11 +408,11 @@ public final class JsonLdOptions {
         return numericId;
     }
 
-    public Cache<String, ActiveContext> getContextCache() {
+    public Cache<String, JsonValue> getContextCache() {
         return contextCache;
     }
 
-    public void setContextCache(Cache<String, ActiveContext> contextCache) {
+    public void setContextCache(Cache<String, JsonValue> contextCache) {
         this.contextCache = contextCache;
     }
 

--- a/src/main/java/com/apicatalog/jsonld/context/ActiveContextBuilder.java
+++ b/src/main/java/com/apicatalog/jsonld/context/ActiveContextBuilder.java
@@ -464,7 +464,6 @@ public final class ActiveContextBuilder {
     }
 
     private void fetch(final String context, final URI baseUrl) throws JsonLdError {
-
         String contextUri = context;
 
         // 5.2.1
@@ -491,13 +490,17 @@ public final class ActiveContextBuilder {
 
         remoteContexts.add(contextUri);
 
-        // if the context has been processed already
+        // 5.2.4
         if (activeContext.getOptions() != null
                 && activeContext.getOptions().getContextCache() != null
                 && activeContext.getOptions().getContextCache().containsKey(contextUri) && !validateScopedContext) {
 
-            // then return the context from a cache
-            result = activeContext.getOptions().getContextCache().get(contextUri);
+            JsonValue cachedContext = activeContext.getOptions().getContextCache().get(contextUri);
+            result = result
+                    .newContext()
+                    .remoteContexts(new ArrayList<>(remoteContexts))
+                    .validateScopedContext(validateScopedContext)
+                    .create(cachedContext, URI.create(contextUri));
             return;
         }
 
@@ -572,7 +575,7 @@ public final class ActiveContextBuilder {
                         .create(importedContext, remoteImport.getDocumentUrl());
 
             if (result.getOptions() != null && result.getOptions().getContextCache() != null && !validateScopedContext) {
-                result.getOptions().getContextCache().put(contextUri, result);
+                result.getOptions().getContextCache().put(contextUri, importedContext);
             }
 
         } catch (JsonLdError e) {


### PR DESCRIPTION
The specification https://www.w3.org/TR/json-ld11-api/#algorithm step 5.2.4 states:
```
If context was previously dereferenced, then the processor MUST NOT do a further dereference, and context is set to the previously established internal representation: set context document to the previously dereferenced document, and set loaded context to the value of the @context entry from the document in context document.
```

The current implementation is not according the specification as caching is done on level of ```context``` not ```context document``` as stated by the specification. This becomes an issue if the same document, remote context, is loaded multiple times. 

In the current implementation, where the whole context in cached I got error on following example:
```
{
  "@context": [
    {
      "@version": 1.1,
      "Pracovní místo": {
        "@id": "https://slovník.gov.cz/datový/pracovní-místa/pojem/pracovní-místo",
        "@context": {
          "kvalifikace": {
            "@id": "https://slovník.gov.cz/datový/pracovní-místa/pojem/požadovaná-kvalifikace",
            "@context":  "http://example.com/práce.json"
          }
        }
      }
    },
    {
      "@version": 1.1,
      "věda": "https://slovník.gov.cz/generický/věda-a-výzkum/pojem/",
      "Výzkumné pracoviště": {
        "@id": "věda:ResearchOrganization",
        "@context": [
         "http://example.com/práce.json",
          {
            "orjk": {
              "@id": "věda:orjk"
            }
          }          
        ]
      }
    }
  ],
  "typ": "Pracoviště",
  "iri": "https://data.mff.cuni.cz/zdroj/číselník/organizační-struktura/oddělení/204"
}
```
where it fail to resolve ```věda:orjk```. 

The reason is that before loading the context with this class the remote context from ```http://example.com/práce.json``` is loaded from the cache. The issue as that the context was resolved using the first context, the one with ```Pracovní místo``` and thus there is no definition of ```věda```. 

The solution is to simple cache the JSON documents, as I believe the specification states. Then then loading the remote context from ```http://example.com/práce.json``` using the cache, it is properly resolved with the current parent. As a result the term ```věda``` is available for resolution of ```věda:orjk```. 