### PR TITLE
Improve URI validation options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.apicatalog</groupId>
     <artifactId>titanium-json-ld</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Titanium JSON-LD 1.1</name>

--- a/src/main/java/com/apicatalog/jsonld/JsonLd.java
+++ b/src/main/java/com/apicatalog/jsonld/JsonLd.java
@@ -58,10 +58,7 @@ public final class JsonLd {
      * @return {@link ExpansionApi} allowing to set additional parameters
      */
     public static final ExpansionApi expand(final String documentLocation) {
-
-        assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME);
-
-        return new ExpansionApi(UriUtils.create(documentLocation));
+        return new ExpansionApi(assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME));
     }
 
     /**
@@ -98,11 +95,10 @@ public final class JsonLd {
      * @return {@link CompactionApi} allowing to set additional parameters
      */
     public static final CompactionApi compact(final String documentLocation, final String contextLocation) {
-
-        assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME);
-        assertLocation(contextLocation, "contextLocation");
-
-        return compact(UriUtils.create(documentLocation), UriUtils.create(contextLocation));
+        return compact(
+                assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME),
+                assertLocation(contextLocation, "contextLocation")
+                );
     }
 
     /**
@@ -129,10 +125,12 @@ public final class JsonLd {
      */
     public static final CompactionApi compact(final String documentLocation, final Document context) {
 
-        assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME);
         assertJsonDocument(context, CONTEXT_PARAM_NAME);
 
-        return new CompactionApi(UriUtils.create(documentLocation), context);
+        return new CompactionApi(
+                assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME), 
+                context
+                );
     }
 
     /**
@@ -172,10 +170,7 @@ public final class JsonLd {
      * @return {@link FlatteningApi} allowing to set additional parameters
      */
     public static final FlatteningApi flatten(final String documentLocation) {
-
-        assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME);
-
-        return new FlatteningApi(UriUtils.create(documentLocation));
+        return new FlatteningApi(assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME));
     }
 
     /**
@@ -227,11 +222,10 @@ public final class JsonLd {
      * @return {@link FramingApi} allowing to set additional parameters
      */
     public static final FramingApi frame(final String documentLocation, final String frameLocation) {
-
-        assertLocation(documentLocation, DOCUMENT_URI_PARAM_NAME);
-        assertLocation(frameLocation, FRAME_LOCATION_PARAM_NAME);
-
-        return new FramingApi(UriUtils.create(documentLocation), UriUtils.create(frameLocation));
+        return new FramingApi(
+                assertLocation(documentLocation, DOCUMENT_URI_PARAM_NAME),
+                assertLocation(frameLocation, FRAME_LOCATION_PARAM_NAME)
+                );
     }
 
     /**
@@ -256,10 +250,7 @@ public final class JsonLd {
      * @return {@link ToRdfApi} allowing to set additional parameters
      */
     public static final ToRdfApi toRdf(final String documentLocation) {
-
-        assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME);
-
-        return new ToRdfApi(UriUtils.create(documentLocation));
+        return new ToRdfApi(assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME));
     }
 
     /**
@@ -295,10 +286,7 @@ public final class JsonLd {
      * @return {@link FromRdfApi} allowing to set additional parameters
      */
     public static final FromRdfApi fromRdf(final String documentLocation) {
-
-        assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME);
-
-        return new FromRdfApi(UriUtils.create(documentLocation));
+        return new FromRdfApi(assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME));
     }
 
     /**
@@ -327,7 +315,7 @@ public final class JsonLd {
         return new FromRdfApi(document);
     }
 
-    private static final void assertLocation(final String location, final String param) {
+    private static final URI assertLocation(final String location, final String param) {
 
         assertNotNull(location, param);
 
@@ -335,9 +323,13 @@ public final class JsonLd {
             throw new IllegalArgumentException("'" + param + "' is blank string.");
         }
 
-        if (UriUtils.isNotAbsoluteUri(StringUtils.strip(location))) {
+        final URI uri = UriUtils.create(StringUtils.strip(location));
+
+        if (uri == null || !uri.isAbsolute()) {
             throw new IllegalArgumentException("'" + param + "' is not an absolute URI [" + location + "].");
         }
+
+        return uri;
     }
 
     private static final void assertUri(final URI uri, final String param) {

--- a/src/main/java/com/apicatalog/jsonld/JsonLd.java
+++ b/src/main/java/com/apicatalog/jsonld/JsonLd.java
@@ -128,7 +128,7 @@ public final class JsonLd {
         assertJsonDocument(context, CONTEXT_PARAM_NAME);
 
         return new CompactionApi(
-                assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME), 
+                assertLocation(documentLocation, DOCUMENT_LOCATION_PARAM_NAME),
                 context
                 );
     }

--- a/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
+++ b/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
@@ -116,7 +116,7 @@ public final class JsonLdOptions {
     private Cache<String, Document> documentCache;
 
     private boolean uriValidation;
-    
+
     public JsonLdOptions() {
         this(SchemeRouter.defaultInstance());
     }
@@ -451,23 +451,32 @@ public final class JsonLdOptions {
     }
 
     /**
-     * if disabled only URIs required for processing are parsed and validated. 
-     * An invalid URI may cause skipped records or an exception. 
-     * Enabled by default. 
-     *  
-     * @return true if validation is enabled
+     * if disabled only URIs required for processing are parsed and validated.
+     * Disabling URI validation might improve performance depending on the number of processed URIs.
+     * <p>
+     * <b>Warning:</b> Disabled validation could cause an invalid output.
+     * </p>
+     * <p>
+     * Enabled by default.
+     * </p>
      *
+     * @return true if validation is enabled
      */
     public boolean isUriValidation() {
         return uriValidation;
     }
 
     /**
-     * if disabled only URIs required for processing are parsed and validated. 
-     * An invalid URI may cause skipped records or an exception. 
-     *  
-     * @param enabled set <code>true</code> to enable validation
+     * if disabled only URIs required for processing are parsed and validated.
+     * Disabling URI validation might improve performance depending on the number of processed URIs.
+     * <p>
+     * <b>Warning:</b> Disabled validation could cause an invalid output.
+     * </p>
+     * <p>
+     * Enabled by default.
+     * </p>
      *
+     * @param enabled set <code>true</code> to enable validation
      */
     public void setUriValidation(boolean enabled) {
         this.uriValidation = enabled;

--- a/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
+++ b/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
@@ -41,7 +41,7 @@ public final class JsonLdOptions {
         I18N_DATATYPE,
         COMPOUND_LITERAL
     }
-    
+
     /* default values */
     public static final boolean DEFAULT_RDF_STAR = false;
     public static final boolean DEFAULT_NUMERIC_ID = false;

--- a/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
+++ b/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
@@ -115,6 +115,8 @@ public final class JsonLdOptions {
     // document cache
     private Cache<String, Document> documentCache;
 
+    private boolean uriValidation;
+    
     public JsonLdOptions() {
         this(SchemeRouter.defaultInstance());
     }
@@ -149,6 +151,7 @@ public final class JsonLdOptions {
         this.numericId = false;
         this.contextCache = new LruCache<>(256);
         this.documentCache = null;
+        this.uriValidation = true;
     }
 
     public JsonLdOptions(JsonLdOptions options) {
@@ -179,6 +182,7 @@ public final class JsonLdOptions {
         this.numericId = options.numericId;
         this.contextCache = options.contextCache;
         this.documentCache = options.documentCache;
+        this.uriValidation = options.uriValidation;
     }
 
     /**
@@ -444,5 +448,28 @@ public final class JsonLdOptions {
      */
     public void setRdfStar(boolean rdfStar) {
         this.rdfStar = rdfStar;
+    }
+
+    /**
+     * if disabled only URIs required for processing are parsed and validated. 
+     * An invalid URI may cause skipped records or an exception. 
+     * Enabled by default. 
+     *  
+     * @return true if validation is enabled
+     *
+     */
+    public boolean isUriValidation() {
+        return uriValidation;
+    }
+
+    /**
+     * if disabled only URIs required for processing are parsed and validated. 
+     * An invalid URI may cause skipped records or an exception. 
+     *  
+     * @param enabled set <code>true</code> to enable validation
+     *
+     */
+    public void setUriValidation(boolean enabled) {
+        this.uriValidation = enabled;
     }
 }

--- a/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
+++ b/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
@@ -151,7 +151,7 @@ public final class JsonLdOptions {
         this.numericId = false;
         this.contextCache = new LruCache<>(256);
         this.documentCache = null;
-        this.uriValidation = true;
+        this.uriValidation = false;
     }
 
     public JsonLdOptions(JsonLdOptions options) {

--- a/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
+++ b/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
@@ -41,6 +41,11 @@ public final class JsonLdOptions {
         I18N_DATATYPE,
         COMPOUND_LITERAL
     }
+    
+    /* default values */
+    public static final boolean DEFAULT_RDF_STAR = false;
+    public static final boolean DEFAULT_NUMERIC_ID = false;
+    public static final boolean DEFAULT_URI_VALIDATION = true;
 
     /**
      * The base IRI to use when expanding or compacting the document.
@@ -145,13 +150,13 @@ public final class JsonLdOptions {
         this.requiredAll = false;
 
         // Extension: JSON-LD-STAR (Experimental)
-        this.rdfStar = false;
+        this.rdfStar = DEFAULT_RDF_STAR;
 
         // custom
-        this.numericId = false;
+        this.numericId = DEFAULT_NUMERIC_ID;
         this.contextCache = new LruCache<>(256);
         this.documentCache = null;
-        this.uriValidation = false;
+        this.uriValidation = DEFAULT_URI_VALIDATION;
     }
 
     public JsonLdOptions(JsonLdOptions options) {

--- a/src/main/java/com/apicatalog/jsonld/api/ExpansionApi.java
+++ b/src/main/java/com/apicatalog/jsonld/api/ExpansionApi.java
@@ -70,15 +70,18 @@ public final class ExpansionApi implements CommonApi<ExpansionApi>, LoaderApi<Ex
     @Override
     public ExpansionApi context(String contextLocation) {
 
+        URI contextUri = null;
+
         if (contextLocation != null) {
 
-            if (UriUtils.isNotURI(contextLocation)) {
+            contextUri = UriUtils.create(contextLocation);
+
+            if (contextUri == null) {
                 throw new IllegalArgumentException("Context location must be valid URI or null but is [" + contextLocation + ".");
             }
-            return context(UriUtils.create(contextLocation));
         }
 
-        return context((Document) null);
+        return context(contextUri);
     }
 
     @Override
@@ -108,15 +111,18 @@ public final class ExpansionApi implements CommonApi<ExpansionApi>, LoaderApi<Ex
     @Override
     public ExpansionApi base(String baseLocation) {
 
-        if (baseLocation != null) {
+        URI baseUri = null;
 
-            if (UriUtils.isNotURI(baseLocation)) {
-                throw new IllegalArgumentException("Base location must be valid URI or null but is [" + baseLocation + ".");
+        if (baseLocation != null && !baseLocation.isBlank()) {
+
+            baseUri = UriUtils.create(baseLocation);
+
+            if (baseUri == null) {
+                throw new IllegalArgumentException("Base location must be valid URI or null but is [" + baseLocation + "].");
             }
-            return base(UriUtils.create(baseLocation));
         }
 
-        return base((URI) null);
+        return base(baseUri);
     }
 
     @Override

--- a/src/main/java/com/apicatalog/jsonld/api/ExpansionApi.java
+++ b/src/main/java/com/apicatalog/jsonld/api/ExpansionApi.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import com.apicatalog.jsonld.JsonLdError;
 import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.JsonLdVersion;
+import com.apicatalog.jsonld.StringUtils;
 import com.apicatalog.jsonld.document.Document;
 import com.apicatalog.jsonld.document.JsonDocument;
 import com.apicatalog.jsonld.loader.DocumentLoader;
@@ -113,7 +114,7 @@ public final class ExpansionApi implements CommonApi<ExpansionApi>, LoaderApi<Ex
 
         URI baseUri = null;
 
-        if (baseLocation != null && !baseLocation.isBlank()) {
+        if (StringUtils.isNotBlank(baseLocation)) {
 
             baseUri = UriUtils.create(baseLocation);
 

--- a/src/main/java/com/apicatalog/jsonld/api/FlatteningApi.java
+++ b/src/main/java/com/apicatalog/jsonld/api/FlatteningApi.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import com.apicatalog.jsonld.JsonLdError;
 import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.JsonLdVersion;
+import com.apicatalog.jsonld.StringUtils;
 import com.apicatalog.jsonld.document.Document;
 import com.apicatalog.jsonld.document.JsonDocument;
 import com.apicatalog.jsonld.loader.DocumentLoader;
@@ -83,7 +84,7 @@ public final class FlatteningApi implements CommonApi<FlatteningApi>, LoaderApi<
 
         URI baseUri = null;
 
-        if (baseLocation != null && !baseLocation.isBlank()) {
+        if (StringUtils.isNotBlank(baseLocation)) {
 
             baseUri = UriUtils.create(baseLocation);
 

--- a/src/main/java/com/apicatalog/jsonld/api/FlatteningApi.java
+++ b/src/main/java/com/apicatalog/jsonld/api/FlatteningApi.java
@@ -81,15 +81,18 @@ public final class FlatteningApi implements CommonApi<FlatteningApi>, LoaderApi<
     @Override
     public FlatteningApi base(String baseLocation) {
 
-        if (baseLocation != null) {
+        URI baseUri = null;
 
-            if (UriUtils.isNotURI(baseLocation)) {
+        if (baseLocation != null && !baseLocation.isBlank()) {
+
+            baseUri = UriUtils.create(baseLocation);
+
+            if (baseUri == null) {
                 throw new IllegalArgumentException("Base location must be valid URI or null but is [" + baseLocation + ".");
             }
-            return base(UriUtils.create(baseLocation));
         }
 
-        return base((URI) null);
+        return base(baseUri);
     }
 
     public FlatteningApi compactArrays(boolean enable) {
@@ -122,16 +125,18 @@ public final class FlatteningApi implements CommonApi<FlatteningApi>, LoaderApi<
     @Override
     public FlatteningApi context(final String contextLocation) {
 
+        URI contextUri = null;
+
         if (contextLocation != null) {
 
-            if (UriUtils.isNotURI(contextLocation)) {
+            contextUri = UriUtils.create(contextLocation);
+
+            if (contextUri == null) {
                 throw new IllegalArgumentException("Context location must be valid URI or null but is [" + contextLocation + ".");
             }
-
-            return context(UriUtils.create(contextLocation));
         }
 
-        return context((URI) null);
+        return context(contextUri);
     }
 
     @Override

--- a/src/main/java/com/apicatalog/jsonld/api/FramingApi.java
+++ b/src/main/java/com/apicatalog/jsonld/api/FramingApi.java
@@ -117,7 +117,7 @@ public final class FramingApi implements CommonApi<FramingApi>, LoaderApi<Framin
 
     @Override
     public FramingApi base(String baseUri) {
-        return base(URI.create(baseUri));
+        return base(UriUtils.create(baseUri));
     }
 
     @Override

--- a/src/main/java/com/apicatalog/jsonld/api/FramingApi.java
+++ b/src/main/java/com/apicatalog/jsonld/api/FramingApi.java
@@ -77,16 +77,18 @@ public final class FramingApi implements CommonApi<FramingApi>, LoaderApi<Framin
     @Override
     public FramingApi context(String contextLocation) {
 
+        URI contextUri = null;
+
         if (contextLocation != null) {
 
-            if (UriUtils.isNotURI(contextLocation)) {
+            contextUri = UriUtils.create(contextLocation);
+
+            if (contextUri == null) {
                 throw new IllegalArgumentException("Context location must be valid URI or null but is [" + contextLocation + ".");
             }
-
-            return context(UriUtils.create(contextLocation));
         }
 
-        return context((URI) null);
+        return context(contextUri);
     }
 
     @Override

--- a/src/main/java/com/apicatalog/jsonld/api/FromRdfApi.java
+++ b/src/main/java/com/apicatalog/jsonld/api/FromRdfApi.java
@@ -23,6 +23,7 @@ import com.apicatalog.jsonld.JsonLdVersion;
 import com.apicatalog.jsonld.document.Document;
 import com.apicatalog.jsonld.loader.DocumentLoader;
 import com.apicatalog.jsonld.processor.FromRdfProcessor;
+import com.apicatalog.jsonld.uri.UriUtils;
 import com.apicatalog.rdf.RdfDataset;
 
 import jakarta.json.JsonArray;
@@ -73,7 +74,7 @@ public final class FromRdfApi implements CommonApi<FromRdfApi>, LoaderApi<FromRd
 
     @Override
     public FromRdfApi base(String baseUri) {
-        return base(URI.create(baseUri));
+        return base(UriUtils.create(baseUri));
     }
 
     @Override

--- a/src/main/java/com/apicatalog/jsonld/api/ToRdfApi.java
+++ b/src/main/java/com/apicatalog/jsonld/api/ToRdfApi.java
@@ -71,16 +71,18 @@ public final class ToRdfApi implements CommonApi<ToRdfApi>, LoaderApi<ToRdfApi>,
     @Override
     public ToRdfApi context(String contextLocation) {
 
+        URI contextUri = null;
+
         if (contextLocation != null) {
 
-            if (UriUtils.isNotURI(contextLocation)) {
+            contextUri = UriUtils.create(contextLocation);
+
+            if (contextUri == null) {
                 throw new IllegalArgumentException("Context location must be valid URI or null but is [" + contextLocation + ".");
             }
-
-            return context(UriUtils.create(contextLocation));
         }
 
-        return context((URI) null);
+        return context(contextUri);
     }
 
     @Override
@@ -140,16 +142,18 @@ public final class ToRdfApi implements CommonApi<ToRdfApi>, LoaderApi<ToRdfApi>,
     @Override
     public ToRdfApi base(String baseLocation) {
 
-        if (baseLocation != null) {
+        URI baseUri = null;
 
-            if (UriUtils.isNotURI(baseLocation)) {
+        if (baseLocation != null && !baseLocation.isBlank()) {
+
+            baseUri = UriUtils.create(baseLocation);
+
+            if (baseUri == null) {
                 throw new IllegalArgumentException("Base location must be valid URI or null but is [" + baseLocation + ".");
             }
-
-            return base(UriUtils.create(baseLocation));
         }
 
-        return base((URI) null);
+        return base(baseUri);
     }
 
     @Override

--- a/src/main/java/com/apicatalog/jsonld/api/ToRdfApi.java
+++ b/src/main/java/com/apicatalog/jsonld/api/ToRdfApi.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import com.apicatalog.jsonld.JsonLdError;
 import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.JsonLdVersion;
+import com.apicatalog.jsonld.StringUtils;
 import com.apicatalog.jsonld.JsonLdOptions.RdfDirection;
 import com.apicatalog.jsonld.document.Document;
 import com.apicatalog.jsonld.document.JsonDocument;
@@ -144,7 +145,7 @@ public final class ToRdfApi implements CommonApi<ToRdfApi>, LoaderApi<ToRdfApi>,
 
         URI baseUri = null;
 
-        if (baseLocation != null && !baseLocation.isBlank()) {
+        if (StringUtils.isNotBlank(baseLocation)) {
 
             baseUri = UriUtils.create(baseLocation);
 

--- a/src/main/java/com/apicatalog/jsonld/compaction/UriCompaction.java
+++ b/src/main/java/com/apicatalog/jsonld/compaction/UriCompaction.java
@@ -539,15 +539,15 @@ public final class UriCompaction {
         }
 
         // 9.
-        if (UriUtils.isAbsoluteUri(variable)) {
+        final URI uri = UriUtils.create(variable);
 
-            final URI uri = URI.create(variable);
-
-            if (uri.getScheme() != null
-                    && activeContext.getTerm(uri.getScheme()).filter(TermDefinition::isPrefix).isPresent()
-                    && uri.getAuthority() == null) {
+        if (uri != null
+                && uri.isAbsolute()
+                && uri.getScheme() != null
+                && uri.getAuthority() == null
+                && activeContext.getTerm(uri.getScheme()).filter(TermDefinition::isPrefix).isPresent()
+            ) {
                 throw new JsonLdError(JsonLdErrorCode.IRI_CONFUSED_WITH_PREFIX);
-            }
         }
 
         // 10.

--- a/src/main/java/com/apicatalog/jsonld/compaction/UriCompaction.java
+++ b/src/main/java/com/apicatalog/jsonld/compaction/UriCompaction.java
@@ -36,7 +36,6 @@ import com.apicatalog.jsonld.lang.ListObject;
 import com.apicatalog.jsonld.lang.NodeObject;
 import com.apicatalog.jsonld.lang.ValueObject;
 import com.apicatalog.jsonld.uri.UriRelativizer;
-import com.apicatalog.jsonld.uri.UriUtils;
 
 import jakarta.json.JsonArray;
 import jakarta.json.JsonString;
@@ -539,16 +538,18 @@ public final class UriCompaction {
         }
 
         // 9.
-        final URI uri = UriUtils.create(variable);
-
-        if (uri != null
-                && uri.isAbsolute()
-                && uri.getScheme() != null
-                && uri.getAuthority() == null
-                && activeContext.getTerm(uri.getScheme()).filter(TermDefinition::isPrefix).isPresent()
-            ) {
-                throw new JsonLdError(JsonLdErrorCode.IRI_CONFUSED_WITH_PREFIX);
-        }
+        try {
+            final URI uri = URI.create(variable);
+    
+            if (uri != null
+                    && uri.isAbsolute()
+                    && uri.getScheme() != null
+                    && uri.getAuthority() == null
+                    && activeContext.getTerm(uri.getScheme()).filter(TermDefinition::isPrefix).isPresent()
+                ) {
+                    throw new JsonLdError(JsonLdErrorCode.IRI_CONFUSED_WITH_PREFIX);
+            }
+        } catch (IllegalArgumentException e) { /* variable is not URI */ }
 
         // 10.
         if (!vocab && activeContext.getBaseUri() != null && !BlankNode.hasPrefix(variable)) {

--- a/src/main/java/com/apicatalog/jsonld/context/ActiveContext.java
+++ b/src/main/java/com/apicatalog/jsonld/context/ActiveContext.java
@@ -165,7 +165,7 @@ public final class ActiveContext {
     }
 
     public UriExpansion uriExpansion() {
-        return UriExpansion.with(this);
+        return UriExpansion.with(this).uriValidation(options.isUriValidation());
     }
 
     public ValueExpansion valueExpansion() {

--- a/src/main/java/com/apicatalog/jsonld/context/ActiveContextBuilder.java
+++ b/src/main/java/com/apicatalog/jsonld/context/ActiveContextBuilder.java
@@ -16,6 +16,7 @@
 package com.apicatalog.jsonld.context;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -224,11 +225,18 @@ public final class ActiveContextBuilder {
 
                 // 5.6.2.
                 if (JsonUtils.isNotString(contextImport)) {
-                    throw new JsonLdError(JsonLdErrorCode.INVALID_KEYWORD_IMPORT_VALUE);
+                    throw new JsonLdError(JsonLdErrorCode.INVALID_KEYWORD_IMPORT_VALUE, "Invalid context @import value [" + contextImport + "].");
                 }
 
                 // 5.6.3.
-                final String contextImportUri = UriResolver.resolve(baseUrl, ((JsonString) contextImport).getString());
+                final URI contextImportUri;
+
+                try {
+                    contextImportUri = UriResolver.resolveAsUri(baseUrl, ((JsonString) contextImport).getString());
+
+                } catch (URISyntaxException e) {
+                    throw new JsonLdError(JsonLdErrorCode.INVALID_KEYWORD_IMPORT_VALUE, "Invalid context @import value [" + contextImport + "].");
+                }
 
                 // 5.6.4.
                 if (activeContext.getOptions().getDocumentLoader() == null) {
@@ -243,7 +251,7 @@ public final class ActiveContextBuilder {
 
                 try {
 
-                    final Document importedDocument = activeContext.getOptions().getDocumentLoader().loadDocument(URI.create(contextImportUri), loaderOptions);
+                    final Document importedDocument = activeContext.getOptions().getDocumentLoader().loadDocument(contextImportUri, loaderOptions);
 
                     if (importedDocument == null) {
                         throw new JsonLdError(JsonLdErrorCode.INVALID_REMOTE_CONTEXT, "Imported context[" + contextImportUri + "] is null.");
@@ -295,18 +303,24 @@ public final class ActiveContextBuilder {
 
                     final String valueString = ((JsonString) value).getString();
 
-                    if (UriUtils.isURI(valueString)) {
+                    final URI valueUri = StringUtils.isNotBlank(valueString) ? UriUtils.create(valueString) : null;
+
+                    if (valueUri != null) {
 
                         // 5.7.3
-                        if (UriUtils.isAbsoluteUri(valueString)) {
-                            result.setBaseUri(URI.create(valueString));
+                        if (valueUri.isAbsolute()) {
+                            result.setBaseUri(valueUri);
 
                         // 5.7.4
                         } else if (result.getBaseUri() != null) {
 
-                            String resolved = UriResolver.resolve(result.getBaseUri(), valueString);
+                            try {
+                                result.setBaseUri(UriResolver.resolveAsUri(result.getBaseUri(), valueUri));
 
-                            result.setBaseUri(UriUtils.create(resolved));
+                            } catch (URISyntaxException e) {
+                                throw new JsonLdError(JsonLdErrorCode.INVALID_BASE_IRI,
+                                        "An invalid base IRI has been detected [@base = " + valueUri + "].");
+                            }
 
                         } else {
                             LOGGER.log(Level.FINE,
@@ -346,7 +360,7 @@ public final class ActiveContextBuilder {
 
                     if (StringUtils.isBlank(valueString) || BlankNode.hasPrefix(valueString) || UriUtils.isURI(valueString)) {
 
-                        String vocabularyMapping =
+                        final String vocabularyMapping =
                                     result
                                         .uriExpansion()
                                         .vocab(true)
@@ -357,11 +371,11 @@ public final class ActiveContextBuilder {
                             result.setVocabularyMapping(vocabularyMapping);
 
                         } else {
-                            throw new JsonLdError(JsonLdErrorCode.INVALID_VOCAB_MAPPING);
+                            throw new JsonLdError(JsonLdErrorCode.INVALID_VOCAB_MAPPING, "An invalid vocabulary mapping [" + vocabularyMapping + "] has been detected.");
                         }
 
                     } else {
-                        throw new JsonLdError(JsonLdErrorCode.INVALID_VOCAB_MAPPING);
+                        throw new JsonLdError(JsonLdErrorCode.INVALID_VOCAB_MAPPING, "An invalid vocabulary mapping [" + valueString + "] has been detected.");
                     }
 
                 } else {
@@ -464,22 +478,29 @@ public final class ActiveContextBuilder {
     }
 
     private void fetch(final String context, final URI baseUrl) throws JsonLdError {
-        String contextUri = context;
 
-        // 5.2.1
-        if (baseUrl != null) {
-            contextUri = UriResolver.resolve(baseUrl, contextUri);
+        URI contextUri;
 
-        } else if (UriUtils.isNotURI(contextUri)) {
-            throw new JsonLdError(JsonLdErrorCode.LOADING_REMOTE_CONTEXT_FAILED, "Context URI is not URI [" + contextUri + "].");
+        try {
+            contextUri = URI.create(context);
+
+            // 5.2.1
+            if (baseUrl != null) {
+                contextUri = UriResolver.resolveAsUri(baseUrl, contextUri);
+            }
+
+            if (!contextUri.isAbsolute()) {
+                throw new JsonLdError(JsonLdErrorCode.LOADING_REMOTE_CONTEXT_FAILED, "Context URI is not absolute [" + contextUri + "].");
+            }
+
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            throw new JsonLdError(JsonLdErrorCode.LOADING_REMOTE_CONTEXT_FAILED, "Context URI is not URI [" + context + "].");
         }
 
-        if (UriUtils.isNotAbsoluteUri(contextUri)) {
-            throw new JsonLdError(JsonLdErrorCode.LOADING_REMOTE_CONTEXT_FAILED, "Context URI is not absolute [" + contextUri + "].");
-        }
+        final String contextKey = contextUri.toString();
 
         // 5.2.2
-        if (!validateScopedContext && remoteContexts.contains(contextUri)) {
+        if (!validateScopedContext && remoteContexts.contains(contextKey)) {
             return;
         }
 
@@ -488,19 +509,19 @@ public final class ActiveContextBuilder {
             throw new JsonLdError(JsonLdErrorCode.CONTEXT_OVERFLOW, "Too many contexts [>" + MAX_REMOTE_CONTEXTS + "].");
         }
 
-        remoteContexts.add(contextUri);
+        remoteContexts.add(contextKey);
 
         // 5.2.4
         if (activeContext.getOptions() != null
                 && activeContext.getOptions().getContextCache() != null
-                && activeContext.getOptions().getContextCache().containsKey(contextUri) && !validateScopedContext) {
+                && activeContext.getOptions().getContextCache().containsKey(contextKey) && !validateScopedContext) {
 
-            JsonValue cachedContext = activeContext.getOptions().getContextCache().get(contextUri);
+            JsonValue cachedContext = activeContext.getOptions().getContextCache().get(contextKey);
             result = result
                     .newContext()
                     .remoteContexts(new ArrayList<>(remoteContexts))
                     .validateScopedContext(validateScopedContext)
-                    .create(cachedContext, URI.create(contextUri));
+                    .create(cachedContext, contextUri);
             return;
         }
 
@@ -513,9 +534,9 @@ public final class ActiveContextBuilder {
 
         if (activeContext.getOptions() != null
                 && activeContext.getOptions().getDocumentCache() != null
-                && activeContext.getOptions().getDocumentCache().containsKey(contextUri)) {
+                && activeContext.getOptions().getDocumentCache().containsKey(contextKey)) {
 
-            remoteImport = activeContext.getOptions().getDocumentCache().get(contextUri);
+            remoteImport = activeContext.getOptions().getDocumentCache().get(contextKey);
         }
 
         if (remoteImport == null) {
@@ -526,7 +547,7 @@ public final class ActiveContextBuilder {
 
             try {
 
-                remoteImport = activeContext.getOptions().getDocumentLoader().loadDocument(URI.create(contextUri), loaderOptions);
+                remoteImport = activeContext.getOptions().getDocumentLoader().loadDocument(contextUri, loaderOptions);
 
             // 5.2.5.1.
             } catch (JsonLdError e) {
@@ -563,7 +584,7 @@ public final class ActiveContextBuilder {
         if (activeContext.getOptions() != null
                 && activeContext.getOptions().getDocumentCache() != null) {
 
-            activeContext.getOptions().getDocumentCache().put(contextUri, remoteImport);
+            activeContext.getOptions().getDocumentCache().put(contextKey, remoteImport);
         }
 
         // 5.2.6
@@ -575,7 +596,7 @@ public final class ActiveContextBuilder {
                         .create(importedContext, remoteImport.getDocumentUrl());
 
             if (result.getOptions() != null && result.getOptions().getContextCache() != null && !validateScopedContext) {
-                result.getOptions().getContextCache().put(contextUri, importedContext);
+                result.getOptions().getContextCache().put(contextKey, importedContext);
             }
 
         } catch (JsonLdError e) {

--- a/src/main/java/com/apicatalog/jsonld/context/ActiveContextBuilder.java
+++ b/src/main/java/com/apicatalog/jsonld/context/ActiveContextBuilder.java
@@ -16,7 +16,6 @@
 package com.apicatalog.jsonld.context;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -229,14 +228,7 @@ public final class ActiveContextBuilder {
                 }
 
                 // 5.6.3.
-                final URI contextImportUri;
-
-                try {
-                    contextImportUri = UriResolver.resolveAsUri(baseUrl, ((JsonString) contextImport).getString());
-
-                } catch (URISyntaxException e) {
-                    throw new JsonLdError(JsonLdErrorCode.INVALID_KEYWORD_IMPORT_VALUE, "Invalid context @import value [" + contextImport + "].");
-                }
+                final URI contextImportUri = UriResolver.resolveAsUri(baseUrl, ((JsonString) contextImport).getString());
 
                 // 5.6.4.
                 if (activeContext.getOptions().getDocumentLoader() == null) {
@@ -313,14 +305,7 @@ public final class ActiveContextBuilder {
 
                         // 5.7.4
                         } else if (result.getBaseUri() != null) {
-
-                            try {
-                                result.setBaseUri(UriResolver.resolveAsUri(result.getBaseUri(), valueUri));
-
-                            } catch (URISyntaxException e) {
-                                throw new JsonLdError(JsonLdErrorCode.INVALID_BASE_IRI,
-                                        "An invalid base IRI has been detected [@base = " + valueUri + "].");
-                            }
+                            result.setBaseUri(UriResolver.resolveAsUri(result.getBaseUri(), valueUri));
 
                         } else {
                             LOGGER.log(Level.FINE,
@@ -493,7 +478,7 @@ public final class ActiveContextBuilder {
                 throw new JsonLdError(JsonLdErrorCode.LOADING_REMOTE_CONTEXT_FAILED, "Context URI is not absolute [" + contextUri + "].");
             }
 
-        } catch (URISyntaxException | IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             throw new JsonLdError(JsonLdErrorCode.LOADING_REMOTE_CONTEXT_FAILED, "Context URI is not URI [" + context + "].");
         }
 

--- a/src/main/java/com/apicatalog/jsonld/context/TermDefinitionBuilder.java
+++ b/src/main/java/com/apicatalog/jsonld/context/TermDefinitionBuilder.java
@@ -249,7 +249,7 @@ public final class TermDefinitionBuilder {
                     && activeContext.inMode(JsonLdVersion.V1_0))
                     // 12.4.
                     || (Keywords.noneMatch(expandedTypeString, Keywords.ID, Keywords.JSON, Keywords.NONE, Keywords.VOCAB)
-                            && UriUtils.isNotAbsoluteUri(expandedTypeString))) {
+                            && UriUtils.isNotAbsoluteUri(expandedTypeString, activeContext.getOptions().isUriValidation()))) {
                 throw new JsonLdError(JsonLdErrorCode.INVALID_TYPE_MAPPING);
             }
 

--- a/src/main/java/com/apicatalog/jsonld/context/TermDefinitionBuilder.java
+++ b/src/main/java/com/apicatalog/jsonld/context/TermDefinitionBuilder.java
@@ -249,7 +249,7 @@ public final class TermDefinitionBuilder {
                     && activeContext.inMode(JsonLdVersion.V1_0))
                     // 12.4.
                     || (Keywords.noneMatch(expandedTypeString, Keywords.ID, Keywords.JSON, Keywords.NONE, Keywords.VOCAB)
-                            && UriUtils.isNotAbsoluteUri(expandedTypeString, activeContext.getOptions().isUriValidation()))) {
+                            && UriUtils.isNotAbsoluteUri(expandedTypeString, true))) {
                 throw new JsonLdError(JsonLdErrorCode.INVALID_TYPE_MAPPING);
             }
 

--- a/src/main/java/com/apicatalog/jsonld/context/TermDefinitionBuilder.java
+++ b/src/main/java/com/apicatalog/jsonld/context/TermDefinitionBuilder.java
@@ -356,7 +356,7 @@ public final class TermDefinitionBuilder {
                     throw new JsonLdError(JsonLdErrorCode.INVALID_KEYWORD_ALIAS);
                 }
 
-                if (!Keywords.contains(definition.getUriMapping()) && !UriUtils.isURI(definition.getUriMapping())
+                if (!Keywords.contains(definition.getUriMapping()) && UriUtils.isNotURI(definition.getUriMapping())
                         && !BlankNode.hasPrefix(definition.getUriMapping())) {
 
                     throw new JsonLdError(JsonLdErrorCode.INVALID_IRI_MAPPING);

--- a/src/main/java/com/apicatalog/jsonld/deseralization/JsonLdToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/JsonLdToRdf.java
@@ -49,6 +49,7 @@ public final class JsonLdToRdf {
     // optional
     private boolean produceGeneralizedRdf;
     private RdfDirection rdfDirection;
+    private boolean uriValidation;
 
     private JsonLdToRdf(NodeMap nodeMap, RdfDataset dataset) {
         this.nodeMap = nodeMap;
@@ -56,6 +57,7 @@ public final class JsonLdToRdf {
 
         this.produceGeneralizedRdf = false;
         this.rdfDirection = null;
+        this.uriValidation = true;
     }
 
     public static final JsonLdToRdf with(NodeMap nodeMap, RdfDataset dataset) {
@@ -90,7 +92,7 @@ public final class JsonLdToRdf {
 
                     rdfGraphName = Rdf.createBlankNode(graphName);
 
-                } else if (UriUtils.isAbsoluteUri(graphName)) {
+                } else if (UriUtils.isAbsoluteUri(graphName, uriValidation)) {
 
                     rdfGraphName = Rdf.createIRI(graphName);
 
@@ -108,7 +110,7 @@ public final class JsonLdToRdf {
                 if (BlankNode.isWellFormed(subject)) {
                     rdfSubject = Rdf.createBlankNode(subject);
 
-                } else if (UriUtils.isAbsoluteUri(subject)) {
+                } else if (UriUtils.isAbsoluteUri(subject, uriValidation)) {
                     rdfSubject = Rdf.createIRI(subject);
 
                 } else {
@@ -135,7 +137,7 @@ public final class JsonLdToRdf {
                             if (BlankNode.isWellFormed(typeString)) {
                                 rdfObject = Rdf.createBlankNode(typeString);
 
-                            } else if (UriUtils.isAbsoluteUri(typeString)) {
+                            } else if (UriUtils.isAbsoluteUri(typeString, uriValidation)) {
                                 rdfObject = Rdf.createIRI(typeString);
 
                             } else {
@@ -151,37 +153,55 @@ public final class JsonLdToRdf {
                         }
 
                     // 1.3.2.2.
-                    } else if (!Keywords.contains(property)
-                                    && ((BlankNode.isWellFormed(property) && !produceGeneralizedRdf)
-                                     || UriUtils.isAbsoluteUri(property))) {
+                    } else if (!Keywords.contains(property)) {
 
-                        // 1.3.2.5.
-                        for (JsonValue item : nodeMap.get(graphName, subject, property).asJsonArray()) {
-
-                            // 1.3.2.5.1.
-                            final List<RdfTriple> listTriples = new ArrayList<>();
-
-                            // 1.3.2.5.2.
-                            ObjectToRdf
-                                    .with(item.asJsonObject(), listTriples, nodeMap)
-                                    .rdfDirection(rdfDirection)
-                                    .build()
-                                    .ifPresent(rdfObject ->
-                                                        dataset.add(Rdf.createNQuad(
-                                                                    rdfSubject,
-                                                                    Rdf.createResource(property),
-                                                                    rdfObject,
-                                                                    rdfGraphName
-                                                                    )));
-                            // 1.3.2.5.3.
-                            listTriples.stream()
-                                        .map(triple -> Rdf.createNQuad(triple, rdfGraphName))
-                                        .forEach(dataset::add);
+                        final RdfResource rdfProperty;
+                        
+                        if ((BlankNode.isWellFormed(property) && !produceGeneralizedRdf)) {
+                            rdfProperty = Rdf.createBlankNode(property);
+                            
+                        } else if (UriUtils.isAbsoluteUri(property, uriValidation)) {
+                            rdfProperty = Rdf.createIRI(property);
+                            
+                        } else {
+                            rdfProperty = null;
+                        }
+                        
+                        if (rdfProperty != null) {                        
+                            // 1.3.2.5.
+                            for (JsonValue item : nodeMap.get(graphName, subject, property).asJsonArray()) {
+    
+                                // 1.3.2.5.1.
+                                final List<RdfTriple> listTriples = new ArrayList<>();
+    
+                                // 1.3.2.5.2.
+                                ObjectToRdf
+                                        .with(item.asJsonObject(), listTriples, nodeMap)
+                                        .rdfDirection(rdfDirection)
+                                        .uriValidation(uriValidation)
+                                        .build()
+                                        .ifPresent(rdfObject ->
+                                                            dataset.add(Rdf.createNQuad(
+                                                                        rdfSubject,
+                                                                        rdfProperty,
+                                                                        rdfObject,
+                                                                        rdfGraphName
+                                                                        )));
+                                // 1.3.2.5.3.
+                                listTriples.stream()
+                                            .map(triple -> Rdf.createNQuad(triple, rdfGraphName))
+                                            .forEach(dataset::add);
+                            }
                         }
                     }
                 }
             }
         }
         return dataset;
+    }
+
+    public JsonLdToRdf uriValidation(boolean uriValidation) {
+        this.uriValidation = uriValidation;
+        return this;
     }
 }

--- a/src/main/java/com/apicatalog/jsonld/deseralization/JsonLdToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/JsonLdToRdf.java
@@ -21,6 +21,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.apicatalog.jsonld.JsonLdError;
+import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.JsonLdOptions.RdfDirection;
 import com.apicatalog.jsonld.flattening.NodeMap;
 import com.apicatalog.jsonld.json.JsonUtils;
@@ -57,7 +58,7 @@ public final class JsonLdToRdf {
 
         this.produceGeneralizedRdf = false;
         this.rdfDirection = null;
-        this.uriValidation = true;
+        this.uriValidation = JsonLdOptions.DEFAULT_URI_VALIDATION;
     }
 
     public static final JsonLdToRdf with(NodeMap nodeMap, RdfDataset dataset) {

--- a/src/main/java/com/apicatalog/jsonld/deseralization/JsonLdToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/JsonLdToRdf.java
@@ -157,8 +157,8 @@ public final class JsonLdToRdf {
 
                         final RdfResource rdfProperty;
                         
-                        if ((BlankNode.isWellFormed(property) && !produceGeneralizedRdf)) {
-                            rdfProperty = Rdf.createBlankNode(property);
+                        if (BlankNode.isWellFormed(property)) {
+                            rdfProperty = !produceGeneralizedRdf ? Rdf.createBlankNode(property) : null;
                             
                         } else if (UriUtils.isAbsoluteUri(property, uriValidation)) {
                             rdfProperty = Rdf.createIRI(property);
@@ -166,8 +166,9 @@ public final class JsonLdToRdf {
                         } else {
                             rdfProperty = null;
                         }
-                        
-                        if (rdfProperty != null) {                        
+
+                        if (rdfProperty != null) {
+
                             // 1.3.2.5.
                             for (JsonValue item : nodeMap.get(graphName, subject, property).asJsonArray()) {
     

--- a/src/main/java/com/apicatalog/jsonld/deseralization/JsonLdToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/JsonLdToRdf.java
@@ -156,13 +156,13 @@ public final class JsonLdToRdf {
                     } else if (!Keywords.contains(property)) {
 
                         final RdfResource rdfProperty;
-                        
+
                         if (BlankNode.isWellFormed(property)) {
                             rdfProperty = !produceGeneralizedRdf ? Rdf.createBlankNode(property) : null;
-                            
+
                         } else if (UriUtils.isAbsoluteUri(property, uriValidation)) {
                             rdfProperty = Rdf.createIRI(property);
-                            
+
                         } else {
                             rdfProperty = null;
                         }
@@ -171,10 +171,10 @@ public final class JsonLdToRdf {
 
                             // 1.3.2.5.
                             for (JsonValue item : nodeMap.get(graphName, subject, property).asJsonArray()) {
-    
+
                                 // 1.3.2.5.1.
                                 final List<RdfTriple> listTriples = new ArrayList<>();
-    
+
                                 // 1.3.2.5.2.
                                 ObjectToRdf
                                         .with(item.asJsonObject(), listTriples, nodeMap)

--- a/src/main/java/com/apicatalog/jsonld/deseralization/ListToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/ListToRdf.java
@@ -51,7 +51,7 @@ final class ListToRdf {
         this.list = list;
         this.triples = triples;
         this.nodeMap = nodeMap;
-        
+
         // default values
         this.rdfDirection = null;
         this.uriValidation = true;

--- a/src/main/java/com/apicatalog/jsonld/deseralization/ListToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/ListToRdf.java
@@ -45,11 +45,16 @@ final class ListToRdf {
 
     // optional
     private RdfDirection rdfDirection;
+    private boolean uriValidation;
 
     private ListToRdf(final JsonArray list, final List<RdfTriple> triples, NodeMap nodeMap) {
         this.list = list;
         this.triples = triples;
         this.nodeMap = nodeMap;
+        
+        // default values
+        this.rdfDirection = null;
+        this.uriValidation = true;
     }
 
     public static final ListToRdf with(final JsonArray list, final List<RdfTriple> triples, NodeMap nodeMap) {
@@ -87,6 +92,7 @@ final class ListToRdf {
             ObjectToRdf
                 .with(item.asJsonObject(), embeddedTriples, nodeMap)
                 .rdfDirection(rdfDirection)
+                .uriValidation(uriValidation)
                 .build()
                 .ifPresent(object ->
                                 triples.add(Rdf.createTriple(
@@ -111,5 +117,10 @@ final class ListToRdf {
 
         // 4.
         return Rdf.createBlankNode(bnodes[0]);
+    }
+
+    public ListToRdf uriValidation(boolean uriValidation) {
+        this.uriValidation = uriValidation;
+        return this;
     }
 }

--- a/src/main/java/com/apicatalog/jsonld/deseralization/ListToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/ListToRdf.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 import com.apicatalog.jsonld.JsonLdError;
+import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.JsonLdOptions.RdfDirection;
 import com.apicatalog.jsonld.flattening.NodeMap;
 import com.apicatalog.jsonld.json.JsonUtils;
@@ -54,7 +55,7 @@ final class ListToRdf {
 
         // default values
         this.rdfDirection = null;
-        this.uriValidation = true;
+        this.uriValidation = JsonLdOptions.DEFAULT_URI_VALIDATION;
     }
 
     public static final ListToRdf with(final JsonArray list, final List<RdfTriple> triples, NodeMap nodeMap) {

--- a/src/main/java/com/apicatalog/jsonld/deseralization/ObjectToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/ObjectToRdf.java
@@ -66,6 +66,7 @@ final class ObjectToRdf {
 
     // optional
     private RdfDirection rdfDirection;
+    private boolean uriValidation;
 
     private ObjectToRdf(JsonObject item, List<RdfTriple> triples, NodeMap nodeMap) {
         this.item = item;
@@ -74,6 +75,7 @@ final class ObjectToRdf {
 
         // default values
         this.rdfDirection = null;
+        this.uriValidation = true;
     }
 
     public static final ObjectToRdf with(JsonObject item, List<RdfTriple> triples, NodeMap nodeMap) {
@@ -101,7 +103,7 @@ final class ObjectToRdf {
             if (BlankNode.isWellFormed(idString)) {
                 return Optional.of(Rdf.createBlankNode(idString));
 
-            } else if (UriUtils.isAbsoluteUri(idString)) {
+            } else if (UriUtils.isAbsoluteUri(idString, uriValidation)) {
                 return Optional.of(Rdf.createIRI(idString));
             }
 
@@ -113,6 +115,7 @@ final class ObjectToRdf {
             return Optional.of(ListToRdf
                         .with(item.get(Keywords.LIST).asJsonArray(), triples, nodeMap)
                         .rdfDirection(rdfDirection)
+                        .uriValidation(uriValidation)
                         .build());
         }
 
@@ -129,7 +132,7 @@ final class ObjectToRdf {
                             : null;
 
         // 6.
-        if (datatype != null && !Keywords.JSON.equals(datatype) && !UriUtils.isAbsoluteUri(datatype)) {
+        if (datatype != null && !Keywords.JSON.equals(datatype) && !UriUtils.isAbsoluteUri(datatype, uriValidation)) {
             return Optional.empty();
         }
 
@@ -282,5 +285,10 @@ final class ObjectToRdf {
 
     private static final String toXsdDouble(BigDecimal bigDecimal) {
         return xsdNumberFormat.format(bigDecimal);
+    }
+
+    public ObjectToRdf uriValidation(boolean uriValidation) {
+        this.uriValidation = uriValidation;
+        return this;
     }
 }

--- a/src/main/java/com/apicatalog/jsonld/deseralization/ObjectToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/ObjectToRdf.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 import java.util.Optional;
 
 import com.apicatalog.jsonld.JsonLdError;
+import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.JsonLdOptions.RdfDirection;
 import com.apicatalog.jsonld.flattening.NodeMap;
 import com.apicatalog.jsonld.json.JsonCanonicalizer;
@@ -75,7 +76,7 @@ final class ObjectToRdf {
 
         // default values
         this.rdfDirection = null;
-        this.uriValidation = true;
+        this.uriValidation = JsonLdOptions.DEFAULT_URI_VALIDATION;
     }
 
     public static final ObjectToRdf with(JsonObject item, List<RdfTriple> triples, NodeMap nodeMap) {

--- a/src/main/java/com/apicatalog/jsonld/expansion/ObjectExpansion1314.java
+++ b/src/main/java/com/apicatalog/jsonld/expansion/ObjectExpansion1314.java
@@ -287,13 +287,12 @@ final class ObjectExpansion1314 {
                                             || value.asJsonArray().stream().anyMatch(JsonUtils::isNotString)
                                         )
                                     && !DefaultObject.isDefaultObject(value)
-                                    && (DefaultObject.getValue(value).map(JsonUtils::isNotString).orElse(true)
-                                            || DefaultObject.getValue(value)
-                                                            .map(JsonString.class::cast)
-                                                            .map(JsonString::getString)
-                                                            .map(UriUtils::isNotURI)
-                                                            .orElse(true)
-                                            )
+                                    && DefaultObject.getValue(value)
+                                                    .filter(JsonUtils::isString)
+                                                    .map(JsonString.class::cast)
+                                                    .map(JsonString::getString)
+                                                    .map(UriUtils::isNotURI)
+                                                    .orElse(true)
                             ) {
 
                         throw new JsonLdError(JsonLdErrorCode.INVALID_TYPE_VALUE, "@type value is not valid [" + value + "].");

--- a/src/main/java/com/apicatalog/jsonld/expansion/UriExpansion.java
+++ b/src/main/java/com/apicatalog/jsonld/expansion/UriExpansion.java
@@ -50,6 +50,7 @@ public final class UriExpansion {
     // optional
     private boolean documentRelative;
     private boolean vocab;
+    private boolean uriValidation;
 
     private JsonObject localContext;
     private Map<String, Boolean> defined;
@@ -62,6 +63,7 @@ public final class UriExpansion {
         this.vocab = false;
         this.localContext = null;
         this.defined = null;
+        this.uriValidation = true;
     }
 
     public static final UriExpansion with(final ActiveContext activeContext) {
@@ -136,7 +138,7 @@ public final class UriExpansion {
             result = initPropertyContext(split[0], split[1], result);
 
             // 6.5
-            if (UriUtils.isAbsoluteUri(result) || BlankNode.hasPrefix(result)) {
+            if (BlankNode.hasPrefix(result) || UriUtils.isAbsoluteUri(result, uriValidation)) {
                 return result;
             }
         }
@@ -202,5 +204,10 @@ public final class UriExpansion {
 
         // 9.
         return result;
+    }
+
+    public UriExpansion uriValidation(boolean uriValidation) {
+        this.uriValidation = uriValidation;
+        return this;
     }
 }

--- a/src/main/java/com/apicatalog/jsonld/expansion/UriExpansion.java
+++ b/src/main/java/com/apicatalog/jsonld/expansion/UriExpansion.java
@@ -21,6 +21,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.apicatalog.jsonld.JsonLdError;
+import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.context.ActiveContext;
 import com.apicatalog.jsonld.context.TermDefinition;
 import com.apicatalog.jsonld.json.JsonUtils;
@@ -63,7 +64,7 @@ public final class UriExpansion {
         this.vocab = false;
         this.localContext = null;
         this.defined = null;
-        this.uriValidation = true;
+        this.uriValidation = JsonLdOptions.DEFAULT_URI_VALIDATION;
     }
 
     public static final UriExpansion with(final ActiveContext activeContext) {

--- a/src/main/java/com/apicatalog/jsonld/flattening/NodeMapBuilder.java
+++ b/src/main/java/com/apicatalog/jsonld/flattening/NodeMapBuilder.java
@@ -220,7 +220,7 @@ public final class NodeMapBuilder {
             if (elementObject.containsKey(Keywords.ID)) {
 
                 final JsonValue idValue = elementObject.get(Keywords.ID);
-                
+
                 if (JsonUtils.isNull(idValue) || JsonUtils.isNotString(idValue)) {
                     return nodeMap;
                 }

--- a/src/main/java/com/apicatalog/jsonld/framing/Frame.java
+++ b/src/main/java/com/apicatalog/jsonld/framing/Frame.java
@@ -45,18 +45,7 @@ public final class Frame {
         this.frameObject = frameObject;
     }
 
-    /**
-     * Deprecated in favor of {@link #of(JsonStructure, boolean)}.
-     * @param structure
-     * @return
-     * @throws JsonLdError
-     */
-    @Deprecated(since = "1.3.0")
-    public static final Frame of2(final JsonStructure structure) throws JsonLdError {
-        return of(structure, true);
-    }
-    
-    public static final Frame of(final JsonStructure structure, boolean validateUris) throws JsonLdError {
+    public static final Frame of(final JsonStructure structure) throws JsonLdError {
 
         final JsonObject frameObject;
 
@@ -81,12 +70,12 @@ public final class Frame {
         }
 
         // 1.2.
-        if (frameObject.containsKey(Keywords.ID) && !validateFrameId(frameObject, validateUris)) {
+        if (frameObject.containsKey(Keywords.ID) && !validateFrameId(frameObject)) {
             throw new JsonLdError(JsonLdErrorCode.INVALID_FRAME, "Frame @id value is not valid [@id = " + frameObject.get(Keywords.ID) + "].");
         }
 
         // 1.3.
-        if (frameObject.containsKey(Keywords.TYPE) && !validateFrameType(frameObject, validateUris)) {
+        if (frameObject.containsKey(Keywords.TYPE) && !validateFrameType(frameObject)) {
             throw new JsonLdError(JsonLdErrorCode.INVALID_FRAME, "Frame @type value i not valid [@type = " + frameObject.get(Keywords.TYPE) + "].");
         }
         return new Frame(frameObject);
@@ -169,7 +158,7 @@ public final class Frame {
         return defaultValue;
     }
 
-    private static final boolean validateFrameId(JsonObject frame, boolean validateUris) {
+    private static final boolean validateFrameId(JsonObject frame) {
 
         final JsonValue id = frame.get(Keywords.ID);
 
@@ -181,12 +170,12 @@ public final class Frame {
                     || idArray
                         .stream()
                         .noneMatch(item -> JsonUtils.isNotString(item)
-                                            || UriUtils.isNotAbsoluteUri(((JsonString)item).getString(), validateUris)));
+                                            || UriUtils.isNotAbsoluteUri(((JsonString)item).getString(), true)));
         }
-        return JsonUtils.isString(id) && UriUtils.isAbsoluteUri(((JsonString)id).getString(), validateUris);
+        return JsonUtils.isString(id) && UriUtils.isAbsoluteUri(((JsonString)id).getString(), true);
     }
 
-    private static final boolean validateFrameType(JsonObject frame, boolean validateUris) {
+    private static final boolean validateFrameType(JsonObject frame) {
 
         final JsonValue type = frame.get(Keywords.TYPE);
 
@@ -204,12 +193,12 @@ public final class Frame {
                     || typeArray
                         .stream()
                         .noneMatch(item -> JsonUtils.isNotString(item)
-                                            || UriUtils.isNotAbsoluteUri(((JsonString)item).getString(), validateUris)));
+                                            || UriUtils.isNotAbsoluteUri(((JsonString)item).getString(), true)));
         }
 
         return JsonUtils.isEmptyArray(type)
                 || JsonUtils.isEmptyObject(type)
-                || JsonUtils.isString(type) && UriUtils.isAbsoluteUri(((JsonString)type).getString(), validateUris);
+                || JsonUtils.isString(type) && UriUtils.isAbsoluteUri(((JsonString)type).getString(), true);
     }
 
     public Set<String> keys() {

--- a/src/main/java/com/apicatalog/jsonld/framing/Frame.java
+++ b/src/main/java/com/apicatalog/jsonld/framing/Frame.java
@@ -45,7 +45,18 @@ public final class Frame {
         this.frameObject = frameObject;
     }
 
-    public static final Frame of(final JsonStructure structure) throws JsonLdError {
+    /**
+     * Deprecated in favor of {@link #of(JsonStructure, boolean)}.
+     * @param structure
+     * @return
+     * @throws JsonLdError
+     */
+    @Deprecated(since = "1.3.0")
+    public static final Frame of2(final JsonStructure structure) throws JsonLdError {
+        return of(structure, true);
+    }
+    
+    public static final Frame of(final JsonStructure structure, boolean validateUris) throws JsonLdError {
 
         final JsonObject frameObject;
 
@@ -70,12 +81,12 @@ public final class Frame {
         }
 
         // 1.2.
-        if (frameObject.containsKey(Keywords.ID) && !validateFrameId(frameObject)) {
+        if (frameObject.containsKey(Keywords.ID) && !validateFrameId(frameObject, validateUris)) {
             throw new JsonLdError(JsonLdErrorCode.INVALID_FRAME, "Frame @id value is not valid [@id = " + frameObject.get(Keywords.ID) + "].");
         }
 
         // 1.3.
-        if (frameObject.containsKey(Keywords.TYPE) && !validateFrameType(frameObject)) {
+        if (frameObject.containsKey(Keywords.TYPE) && !validateFrameType(frameObject, validateUris)) {
             throw new JsonLdError(JsonLdErrorCode.INVALID_FRAME, "Frame @type value i not valid [@type = " + frameObject.get(Keywords.TYPE) + "].");
         }
         return new Frame(frameObject);
@@ -158,7 +169,7 @@ public final class Frame {
         return defaultValue;
     }
 
-    private static final boolean validateFrameId(JsonObject frame) {
+    private static final boolean validateFrameId(JsonObject frame, boolean validateUris) {
 
         final JsonValue id = frame.get(Keywords.ID);
 
@@ -170,12 +181,12 @@ public final class Frame {
                     || idArray
                         .stream()
                         .noneMatch(item -> JsonUtils.isNotString(item)
-                                            || UriUtils.isNotAbsoluteUri(((JsonString)item).getString())));
+                                            || UriUtils.isNotAbsoluteUri(((JsonString)item).getString(), validateUris)));
         }
-        return JsonUtils.isString(id) && UriUtils.isAbsoluteUri(((JsonString)id).getString());
+        return JsonUtils.isString(id) && UriUtils.isAbsoluteUri(((JsonString)id).getString(), validateUris);
     }
 
-    private static final boolean validateFrameType(JsonObject frame) {
+    private static final boolean validateFrameType(JsonObject frame, boolean validateUris) {
 
         final JsonValue type = frame.get(Keywords.TYPE);
 
@@ -193,12 +204,12 @@ public final class Frame {
                     || typeArray
                         .stream()
                         .noneMatch(item -> JsonUtils.isNotString(item)
-                                            || UriUtils.isNotAbsoluteUri(((JsonString)item).getString())));
+                                            || UriUtils.isNotAbsoluteUri(((JsonString)item).getString(), validateUris)));
         }
 
         return JsonUtils.isEmptyArray(type)
                 || JsonUtils.isEmptyObject(type)
-                || JsonUtils.isString(type) && UriUtils.isAbsoluteUri(((JsonString)type).getString());
+                || JsonUtils.isString(type) && UriUtils.isAbsoluteUri(((JsonString)type).getString(), validateUris);
     }
 
     public Set<String> keys() {

--- a/src/main/java/com/apicatalog/jsonld/framing/FrameMatcher.java
+++ b/src/main/java/com/apicatalog/jsonld/framing/FrameMatcher.java
@@ -38,14 +38,25 @@ public final class FrameMatcher {
     private Frame frame;
     private boolean requireAll;
 
+    // optional
+    private boolean validateUris;
+    
     private FrameMatcher(FramingState state, Frame frame, boolean requireAll) {
         this.state = state;
         this.frame = frame;
         this.requireAll = requireAll;
+        
+        // optional
+        this.validateUris = true;
     }
 
     public static final FrameMatcher with(FramingState state, Frame frame, boolean requireAll) {
         return new FrameMatcher(state, frame, requireAll);
+    }
+    
+    public FrameMatcher validateUris(boolean enable) {
+        this.validateUris = enable;
+        return this;
     }
 
     public List<String> match(final Collection<String> subjects) throws JsonLdError {
@@ -124,7 +135,7 @@ public final class FrameMatcher {
 
             final Frame propertyFrame =
                             (JsonUtils.isNotNull(propertyValue) && JsonUtils.isNonEmptyArray(propertyValue))
-                                ? Frame.of((JsonStructure)propertyValue)
+                                ? Frame.of((JsonStructure)propertyValue, validateUris)
                                 : null;
 
             final JsonArray nodeValues = nodeValue != null
@@ -188,7 +199,7 @@ public final class FrameMatcher {
 
                             for (final JsonValue value : JsonUtils.toCollection(nodeListValue)) {
 
-                                match = Frame.of((JsonStructure)listValue).matchValue(value);
+                                match = Frame.of((JsonStructure)listValue, validateUris).matchValue(value);
                                 if (match) {
                                     break;
                                 }
@@ -207,7 +218,7 @@ public final class FrameMatcher {
                             boolean match = false;
                             for (final JsonValue value : JsonUtils.toCollection(nodeListValue)) {
 
-                                match = Frame.of((JsonStructure)listValue).matchNode(state, value, requireAll);
+                                match = Frame.of((JsonStructure)listValue, validateUris).matchNode(state, value, requireAll);
 
                                 if (match) {
                                     break;

--- a/src/main/java/com/apicatalog/jsonld/framing/FrameMatcher.java
+++ b/src/main/java/com/apicatalog/jsonld/framing/FrameMatcher.java
@@ -38,25 +38,14 @@ public final class FrameMatcher {
     private Frame frame;
     private boolean requireAll;
 
-    // optional
-    private boolean validateUris;
-    
     private FrameMatcher(FramingState state, Frame frame, boolean requireAll) {
         this.state = state;
         this.frame = frame;
         this.requireAll = requireAll;
-        
-        // optional
-        this.validateUris = true;
     }
 
     public static final FrameMatcher with(FramingState state, Frame frame, boolean requireAll) {
         return new FrameMatcher(state, frame, requireAll);
-    }
-    
-    public FrameMatcher validateUris(boolean enable) {
-        this.validateUris = enable;
-        return this;
     }
 
     public List<String> match(final Collection<String> subjects) throws JsonLdError {
@@ -135,7 +124,7 @@ public final class FrameMatcher {
 
             final Frame propertyFrame =
                             (JsonUtils.isNotNull(propertyValue) && JsonUtils.isNonEmptyArray(propertyValue))
-                                ? Frame.of((JsonStructure)propertyValue, validateUris)
+                                ? Frame.of((JsonStructure)propertyValue)
                                 : null;
 
             final JsonArray nodeValues = nodeValue != null
@@ -199,7 +188,7 @@ public final class FrameMatcher {
 
                             for (final JsonValue value : JsonUtils.toCollection(nodeListValue)) {
 
-                                match = Frame.of((JsonStructure)listValue, validateUris).matchValue(value);
+                                match = Frame.of((JsonStructure)listValue).matchValue(value);
                                 if (match) {
                                     break;
                                 }
@@ -218,7 +207,7 @@ public final class FrameMatcher {
                             boolean match = false;
                             for (final JsonValue value : JsonUtils.toCollection(nodeListValue)) {
 
-                                match = Frame.of((JsonStructure)listValue, validateUris).matchNode(state, value, requireAll);
+                                match = Frame.of((JsonStructure)listValue).matchNode(state, value, requireAll);
 
                                 if (match) {
                                     break;

--- a/src/main/java/com/apicatalog/jsonld/framing/Framing.java
+++ b/src/main/java/com/apicatalog/jsonld/framing/Framing.java
@@ -56,7 +56,6 @@ public final class Framing {
 
     // optional
     private boolean ordered;
-    private boolean validateUris;
 
     private Framing(FramingState state, List<String> subjects, Frame frame, JsonMapBuilder parent, String activeProperty) {
         this.state = state;
@@ -67,7 +66,6 @@ public final class Framing {
 
         // default values
         this.ordered = false;
-        this.validateUris = true;
     }
 
     public static final Framing with(FramingState state, List<String> subjects, Frame frame, JsonMapBuilder parent, String activeProperty) {
@@ -78,11 +76,6 @@ public final class Framing {
         this.ordered = ordered;
         return this;
     }
-    
-    public Framing validateUris(boolean validate) {
-        this.validateUris = validate;
-        return this;
-    }    
 
     public void frame() throws JsonLdError {
 
@@ -97,7 +90,6 @@ public final class Framing {
         final List<String> matchedSubjects =
                                 FrameMatcher
                                     .with(state, frame, requireAll)
-                                    .validateUris(validateUris)
                                     .match(subjects);
 
         // 4.
@@ -156,7 +148,7 @@ public final class Framing {
 
                 if (!frame.contains(Keywords.GRAPH)) {
                     recurse = !Keywords.MERGED.equals(state.getGraphName());
-                    subframe = Frame.of(JsonValue.EMPTY_JSON_OBJECT, false);
+                    subframe = Frame.of(JsonValue.EMPTY_JSON_OBJECT);
 
                 // 4.5.2.
                 } else {
@@ -166,10 +158,10 @@ public final class Framing {
                             || JsonUtils.isArray(frame.get(Keywords.GRAPH))
                             ) {
 
-                        subframe = Frame.of((JsonStructure)frame.get(Keywords.GRAPH), validateUris);
+                        subframe = Frame.of((JsonStructure)frame.get(Keywords.GRAPH));
 
                     } else {
-                        subframe = Frame.of(JsonValue.EMPTY_JSON_OBJECT, false);
+                        subframe = Frame.of(JsonValue.EMPTY_JSON_OBJECT);
                     }
                 }
 
@@ -189,7 +181,6 @@ public final class Framing {
                                 Keywords.GRAPH
                                 )
                             .ordered(ordered)
-                            .validateUris(validateUris)
                             .frame();
                 }
             }
@@ -203,12 +194,11 @@ public final class Framing {
                 Framing.with(
                             includedState,
                             subjects,
-                            Frame.of((JsonStructure)frame.get(Keywords.INCLUDED), validateUris),
+                            Frame.of((JsonStructure)frame.get(Keywords.INCLUDED)),
                             output,
                             Keywords.INCLUDED
                             )
                         .ordered(ordered)
-                        .validateUris(validateUris)
                         .frame();
             }
 
@@ -276,11 +266,10 @@ public final class Framing {
                                     Framing.with(
                                                 listState,
                                                 Arrays.asList(listItem.asJsonObject().getString(Keywords.ID)),
-                                                Frame.of((JsonStructure)listFrame, validateUris),
+                                                Frame.of((JsonStructure)listFrame),
                                                 listResult,
                                                 Keywords.LIST)
                                             .ordered(ordered)
-                                            .validateUris(validateUris)
                                             .frame();
 
                                     if (listResult.containsKey(Keywords.LIST)) {
@@ -303,15 +292,14 @@ public final class Framing {
                         Framing.with(
                                     clonedState,
                                     Arrays.asList(item.asJsonObject().getString(Keywords.ID)),
-                                    Frame.of((JsonStructure)subframe, validateUris),
+                                    Frame.of((JsonStructure)subframe),
                                     output,
                                     property)
                                 .ordered(ordered)
-                                .validateUris(validateUris)
                                 .frame();
 
                     } else if (ValueObject.isValueObject(item)) {
-                        if (Frame.of((JsonStructure)subframe, validateUris).matchValue(item)) {
+                        if (Frame.of((JsonStructure)subframe).matchValue(item)) {
                             output.add(property, item);
                         }
 
@@ -391,11 +379,10 @@ public final class Framing {
                                 Framing.with(
                                             reverseState,
                                             Arrays.asList(subjectProperty),
-                                            Frame.of((JsonStructure)subframe, validateUris),
+                                            Frame.of((JsonStructure)subframe),
                                             reverseResult,
                                             null)
                                         .ordered(ordered)
-                                        .validateUris(validateUris)
                                         .frame();
 
                                 output

--- a/src/main/java/com/apicatalog/jsonld/lang/BlankNode.java
+++ b/src/main/java/com/apicatalog/jsonld/lang/BlankNode.java
@@ -31,6 +31,12 @@ public final class BlankNode {
 
     }
 
+    /**
+     * Returns <code>true</code> if the given value starts with a blank node prefix '<code>_:</code>'.
+     *
+     * @param value to check
+     * @return <code>true</code> if the give value has blank node prefix
+     */
     public static boolean hasPrefix(final String value) {
         return value.startsWith("_:");
     }

--- a/src/main/java/com/apicatalog/jsonld/loader/DefaultHttpLoader.java
+++ b/src/main/java/com/apicatalog/jsonld/loader/DefaultHttpLoader.java
@@ -18,6 +18,7 @@ package com.apicatalog.jsonld.loader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -84,7 +85,11 @@ class DefaultHttpLoader implements DocumentLoader {
                         final Optional<String> location = response.location();
 
                         if (location.isPresent()) {
-                            targetUri = URI.create(UriResolver.resolve(targetUri, location.get()));
+                            try {
+                                targetUri = UriResolver.resolveAsUri(targetUri, location.get());
+                            } catch (URISyntaxException e) {
+                                throw new JsonLdError(JsonLdErrorCode.LOADING_DOCUMENT_FAILED, "Header location value is invalid [" + location.get() + "].");
+                            }
 
                         } else {
                             throw new JsonLdError(JsonLdErrorCode.LOADING_DOCUMENT_FAILED, "Header location is required for code [" + response.statusCode() + "].");

--- a/src/main/java/com/apicatalog/jsonld/loader/DefaultHttpLoader.java
+++ b/src/main/java/com/apicatalog/jsonld/loader/DefaultHttpLoader.java
@@ -18,7 +18,6 @@ package com.apicatalog.jsonld.loader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -85,17 +84,11 @@ class DefaultHttpLoader implements DocumentLoader {
                         final Optional<String> location = response.location();
 
                         if (location.isPresent()) {
-                            try {
-                                targetUri = UriResolver.resolveAsUri(targetUri, location.get());
-                            } catch (URISyntaxException e) {
-                                throw new JsonLdError(JsonLdErrorCode.LOADING_DOCUMENT_FAILED, "Header location value is invalid [" + location.get() + "].");
-                            }
-
-                        } else {
-                            throw new JsonLdError(JsonLdErrorCode.LOADING_DOCUMENT_FAILED, "Header location is required for code [" + response.statusCode() + "].");
+                            targetUri = UriResolver.resolveAsUri(targetUri, location.get());
+                            continue;
                         }
 
-                        continue;
+                        throw new JsonLdError(JsonLdErrorCode.LOADING_DOCUMENT_FAILED, "Header location is required for code [" + response.statusCode() + "].");
                     }
 
                     if (response.statusCode() != 200) {

--- a/src/main/java/com/apicatalog/jsonld/processor/FramingProcessor.java
+++ b/src/main/java/com/apicatalog/jsonld/processor/FramingProcessor.java
@@ -140,12 +140,11 @@ public final class FramingProcessor {
         // 16.
         Framing.with(state,
                     new ArrayList<>(state.getGraphMap().subjects(state.getGraphName())),
-                    Frame.of(expandedFrame, options.isUriValidation()),
+                    Frame.of(expandedFrame),
                     resultMap,
                     null
                     )
                 .ordered(options.isOrdered())
-                .validateUris(options.isUriValidation())
                 .frame();
 
         Stream<JsonValue> result = resultMap.valuesToArray().stream();

--- a/src/main/java/com/apicatalog/jsonld/processor/FramingProcessor.java
+++ b/src/main/java/com/apicatalog/jsonld/processor/FramingProcessor.java
@@ -140,11 +140,12 @@ public final class FramingProcessor {
         // 16.
         Framing.with(state,
                     new ArrayList<>(state.getGraphMap().subjects(state.getGraphName())),
-                    Frame.of(expandedFrame),
+                    Frame.of(expandedFrame, options.isUriValidation()),
                     resultMap,
                     null
                     )
                 .ordered(options.isOrdered())
+                .validateUris(options.isUriValidation())
                 .frame();
 
         Stream<JsonValue> result = resultMap.valuesToArray().stream();

--- a/src/main/java/com/apicatalog/jsonld/processor/FromRdfProcessor.java
+++ b/src/main/java/com/apicatalog/jsonld/processor/FromRdfProcessor.java
@@ -40,6 +40,7 @@ public final class FromRdfProcessor {
                     .useNativeTypes(options.isUseNativeTypes())
                     .useRdfType(options.isUseRdfType())
                     .processingMode(options.getProcessingMode())
+                    .uriValidation(options.isUriValidation())
                     .build();
     }
 

--- a/src/main/java/com/apicatalog/jsonld/processor/ToRdfProcessor.java
+++ b/src/main/java/com/apicatalog/jsonld/processor/ToRdfProcessor.java
@@ -75,6 +75,7 @@ public final class ToRdfProcessor {
                             )
                         .produceGeneralizedRdf(options.isProduceGeneralizedRdf())
                         .rdfDirection(options.getRdfDirection())
+                        .uriValidation(options.isUriValidation())
                         .build();
     }
 }

--- a/src/main/java/com/apicatalog/jsonld/serialization/RdfToJsonld.java
+++ b/src/main/java/com/apicatalog/jsonld/serialization/RdfToJsonld.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import com.apicatalog.jsonld.JsonLdError;
 import com.apicatalog.jsonld.JsonLdErrorCode;
+import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.JsonLdVersion;
 import com.apicatalog.jsonld.JsonLdOptions.RdfDirection;
 import com.apicatalog.jsonld.json.JsonUtils;
@@ -75,7 +76,7 @@ public final class RdfToJsonld {
         this.rdfDirection = null;
         this.useNativeTypes = false;
         this.useRdfType = false;
-        this.uriValidation = true;
+        this.uriValidation = JsonLdOptions.DEFAULT_URI_VALIDATION;
     }
 
     public static final RdfToJsonld with(final RdfDataset dataset) {

--- a/src/main/java/com/apicatalog/jsonld/serialization/RdfToJsonld.java
+++ b/src/main/java/com/apicatalog/jsonld/serialization/RdfToJsonld.java
@@ -56,6 +56,7 @@ public final class RdfToJsonld {
     private RdfDirection rdfDirection;
     private boolean useNativeTypes;
     private boolean useRdfType;
+    private boolean uriValidation;
 
     private JsonLdVersion processingMode;
 
@@ -74,6 +75,7 @@ public final class RdfToJsonld {
         this.rdfDirection = null;
         this.useNativeTypes = false;
         this.useRdfType = false;
+        this.uriValidation = true;
     }
 
     public static final RdfToJsonld with(final RdfDataset dataset) {
@@ -260,7 +262,7 @@ public final class RdfToJsonld {
                     nodeId = ((JsonString)node.get(Keywords.ID)).getString();
 
                     // 6.4.3.5.
-                    if (UriUtils.isAbsoluteUri(nodeId)) {
+                    if (UriUtils.isAbsoluteUri(nodeId, uriValidation)) {
                         break;
                     }
                 }
@@ -429,5 +431,10 @@ public final class RdfToJsonld {
         private String subject;
         private String property;
         private JsonObject value;
+    }
+
+    public RdfToJsonld uriValidation(boolean uriValidation) {
+        this.uriValidation = uriValidation;
+        return this;
     }
 }

--- a/src/main/java/com/apicatalog/jsonld/serialization/RdfToObject.java
+++ b/src/main/java/com/apicatalog/jsonld/serialization/RdfToObject.java
@@ -108,7 +108,7 @@ final class RdfToObject {
                 } else if (XsdConstants.INTEGER.equals(literal.getDatatype()) || XsdConstants.INT.equals(literal.getDatatype()) || XsdConstants.LONG.equals(literal.getDatatype())) {
 
                     convertedValue = Json.createValue(Long.parseLong(literal.getValue()));
-                    
+
                 } else if (XsdConstants.DOUBLE.equals(literal.getDatatype())) {
 
                     convertedValue = Json.createValue(Double.parseDouble(literal.getValue()));

--- a/src/main/java/com/apicatalog/jsonld/uri/UriRelativizer.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriRelativizer.java
@@ -29,7 +29,7 @@ public final class UriRelativizer {
             return uri;
         }
 
-        return relativize(base, URI.create(uri));
+        return relativize(base, UriUtils.create(uri));
     }
 
     public static final String relativize(final URI base, final URI uri) {

--- a/src/main/java/com/apicatalog/jsonld/uri/UriRelativizer.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriRelativizer.java
@@ -29,7 +29,7 @@ public final class UriRelativizer {
             return uri;
         }
 
-        return relativize(base, UriUtils.create(uri));
+        return relativize(base, URI.create(uri));
     }
 
     public static final String relativize(final URI base, final URI uri) {

--- a/src/main/java/com/apicatalog/jsonld/uri/UriResolver.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriResolver.java
@@ -57,7 +57,7 @@ public final class UriResolver {
         return UriUtils.recompose(components[0], components[1], components[2], components[3], components[4]);
     }
 
-    public static final URI resolveAsUri(final URI base, final String relative) throws URISyntaxException {
+    public static final URI resolveAsUri(final URI base, final String relative) {
 
         if (relative == null || relative.trim().isBlank()) {
             return base;
@@ -70,7 +70,7 @@ public final class UriResolver {
         return resolveAsUri(base, UriUtils.create(relative));
     }
 
-    public static final  URI resolveAsUri(final URI base, final URI relative) throws URISyntaxException {
+    public static final  URI resolveAsUri(final URI base, final URI relative) {
 
         if (relative == null) {
             return base;
@@ -82,13 +82,18 @@ public final class UriResolver {
 
         final String[] components = resolveAsComponents(base, relative);
 
-        if (components[0] != null
-                && components[1] == null
-                ) {
-            return new URI(components[0], components[2].trim().isEmpty() ? "." : components[2], components[4]);
-        }
+        try {
+            if (components[0] != null
+                    && components[1] == null
+                    ) {
+                return new URI(components[0], components[2].trim().isEmpty() ? "." : components[2], components[4]);
+            }
 
-        return new URI(components[0], components[1], components[2], components[3], components[4]);
+            return new URI(components[0], components[1], components[2], components[3], components[4]);
+
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e); // should never happen
+        }
     }
 
     private static final String[] resolveAsComponents(final URI base, final URI relative) {

--- a/src/main/java/com/apicatalog/jsonld/uri/UriResolver.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriResolver.java
@@ -49,7 +49,7 @@ public final class UriResolver {
         }
 
         if (base == null) {
-            return relative != null ? relative.toString() : null;
+            return relative.toString();
         }
 
         final String[] components = resolveAsComponents(base, relative);
@@ -64,7 +64,7 @@ public final class UriResolver {
         }
 
         if (base == null) {
-            return relative != null ? UriUtils.create(relative) : null;
+            return UriUtils.create(relative);
         }
 
         return resolveAsUri(base, UriUtils.create(relative));

--- a/src/main/java/com/apicatalog/jsonld/uri/UriResolver.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriResolver.java
@@ -16,6 +16,7 @@
 package com.apicatalog.jsonld.uri;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,12 +39,64 @@ public final class UriResolver {
             return relative;
         }
 
-        URI components = UriUtils.create(relative);
+        return resolve(base, UriUtils.create(relative));
+    }
+
+    public static final String resolve(final URI base, final URI relative) {
+
+        if (relative == null) {
+            return base != null ? base.toString() : null;
+        }
+
+        if (base == null) {
+            return relative != null ? relative.toString() : null;
+        }
+
+        final String[] components = resolveAsComponents(base, relative);
+
+        return UriUtils.recompose(components[0], components[1], components[2], components[3], components[4]);
+    }
+
+    public static final URI resolveAsUri(final URI base, final String relative) throws URISyntaxException {
+
+        if (relative == null || relative.trim().isBlank()) {
+            return base;
+        }
+
+        if (base == null) {
+            return relative != null ? UriUtils.create(relative) : null;
+        }
+
+        return resolveAsUri(base, UriUtils.create(relative));
+    }
+
+    public static final  URI resolveAsUri(final URI base, final URI relative) throws URISyntaxException {
+
+        if (relative == null) {
+            return base;
+        }
+
+        if (base == null) {
+            return relative;
+        }
+
+        final String[] components = resolveAsComponents(base, relative);
+
+        if (components[0] != null
+                && components[1] == null
+                ) {
+            return new URI(components[0], components[2].trim().isEmpty() ? "." : components[2], components[4]);
+        }
+
+        return new URI(components[0], components[1], components[2], components[3], components[4]);
+    }
+
+    private static final String[] resolveAsComponents(final URI base, final URI relative) {
 
         String basePath = base.getPath();
         String baseAuthority = base.getAuthority();
 
-        String componentPath = components.getPath();
+        String componentPath = relative.getPath();
 
         // hacks
         if (baseAuthority == null && base.getSchemeSpecificPart().startsWith("///")) {
@@ -53,60 +106,58 @@ public final class UriResolver {
             basePath = base.getSchemeSpecificPart();
         }
 
-        if (componentPath == null && components.getSchemeSpecificPart() != null) {
-            componentPath = components.getSchemeSpecificPart();
+        if (componentPath == null && relative.getSchemeSpecificPart() != null) {
+            componentPath = relative.getSchemeSpecificPart();
         }
 
-        String scheme = null;
-        String authority = null;
-        String path = null;
-        String query = null;
+        final String[] target = new String[5];
+        target[4] = relative.getFragment();
 
-        if (components.getScheme() != null && StringUtils.isNotBlank(components.getScheme())) {
-            scheme = components.getScheme();
-            authority =  components.getAuthority();
-            path = removeDotSegments(componentPath);
-            query = components.getQuery();
+        if (relative.getScheme() != null && StringUtils.isNotBlank(relative.getScheme())) {
+            target[0] = relative.getScheme();
+            target[1] = relative.getAuthority();
+            target[2] = removeDotSegments(componentPath);
+            target[3] = relative.getQuery();
 
         } else {
 
-            if (components.getAuthority() != null && StringUtils.isNotBlank(components.getAuthority())) {
-                authority = components.getAuthority();
-                path = removeDotSegments(componentPath);
-                query = components.getQuery();
+            if (relative.getAuthority() != null && StringUtils.isNotBlank(relative.getAuthority())) {
+                target[1] = relative.getAuthority();
+                target[2] = removeDotSegments(componentPath);
+                target[3] = relative.getQuery();
 
             } else {
 
                 if (componentPath != null && StringUtils.isNotBlank(componentPath)) {
                     if (componentPath.startsWith("/")) {
-                        path = removeDotSegments(componentPath);
+                        target[2] = removeDotSegments(componentPath);
 
                     } else if (basePath != null && StringUtils.isNotBlank(basePath)) {
+                        target[2] = removeDotSegments(merge(basePath, componentPath));
 
-                        path = removeDotSegments(merge(basePath, componentPath));
                     } else {
-                        path = "/".concat(removeDotSegments(componentPath));
+                        target[2] = "/".concat(removeDotSegments(componentPath));
 
                     }
-                    query = components.getQuery();
+                    target[3] = relative.getQuery();
 
                 } else {
-                    path = basePath;
+                    target[2] = basePath;
 
-                    if (UriUtils.isDefined(components.getQuery())) {
-                        query = components.getQuery();
+                    if (UriUtils.isDefined(relative.getQuery())) {
+                        target[3] = relative.getQuery();
 
                     } else {
-                        query = base.getQuery();
+                        target[3] = base.getQuery();
                     }
 
                 }
-                authority = baseAuthority;
+                target[1] = baseAuthority;
             }
-            scheme = base.getScheme();
+            target[0] = base.getScheme();
         }
 
-        return UriUtils.recompose(scheme, authority, path, query, components.getFragment());
+        return target;
     }
 
     /**

--- a/src/main/java/com/apicatalog/jsonld/uri/UriResolver.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriResolver.java
@@ -59,7 +59,7 @@ public final class UriResolver {
 
     public static final URI resolveAsUri(final URI base, final String relative) {
 
-        if (relative == null || relative.trim().isBlank()) {
+        if (StringUtils.isBlank(relative)) {
             return base;
         }
 

--- a/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
@@ -114,10 +114,30 @@ public final class UriUtils {
 
     public static final boolean isAbsoluteUri(final String uri, final boolean validate) {
 
+        // if URI validation is disabled
         if (!validate) {
-            return uri.indexOf(":") != -1;
+            
+            // then validate just a scheme
+            for (int i = 0; i < uri.length(); i++) {
+
+                // a scheme name must start with a letter
+                if (i == 0 && Character.isLetter(uri.codePointAt(i))
+                        
+                    // followed by a letter/digit/+/-/. 
+                    || (i > 0 && (
+                            Character.isLetterOrDigit(uri.codePointAt(i))
+                            || uri.charAt(i) == '-' || uri.charAt(i) == '+' || uri.charAt(i) == '.'
+                        ))
+                    ) {
+                    continue;
+                }
+
+                // a scheme name must be terminated by ';'
+                return (i > 0 && uri.charAt(i) == ':');
+            }
+            return false;
         }
-        
+
         try {
             return URI.create(uri).isAbsolute();
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
@@ -83,11 +83,36 @@ public final class UriUtils {
                         || create(StringUtils.strip(uri)) == null));
     }
 
+    /**
+     * Deprecated in favor of {@link UriUtils#isNotAbsoluteUri(String, boolean)}
+     * @param uri
+     * @return
+     */
+    @Deprecated(since = "1.3.0")
     public static final boolean isNotAbsoluteUri(final String uri) {
         return !isAbsoluteUri(uri);
     }
 
+    public static final boolean isNotAbsoluteUri(final String uri, final boolean validate) {
+        return !isAbsoluteUri(uri);
+    }
+
+    /**
+     * Deprecated in favor of {@link UriUtils#isAbsoluteUri(String, boolean)}
+     * @param uri
+     * @return
+     */
+    @Deprecated(since = "1.3.0")
     public static final boolean isAbsoluteUri(final String uri) {
+
+        try {
+            return URI.create(uri).isAbsolute();
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public static final boolean isAbsoluteUri(final String uri, final boolean validate) {
 
         try {
             return URI.create(uri).isAbsolute();

--- a/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
@@ -112,30 +112,38 @@ public final class UriUtils {
         }
     }
 
+    private static final boolean startsWithScheme(final String uri) {
+
+        if (uri == null
+                || uri.length() < 2 // a scheme must have at least one letter followed by ':'
+                || !Character.isLetter(uri.codePointAt(0)) // a scheme name must start with a letter
+                ) {
+            return false;
+        }
+
+        for (int i = 1; i < uri.length(); i++) {
+
+            if (
+                //  a scheme name must start with a letter followed by a letter/digit/+/-/.
+                Character.isLetterOrDigit(uri.codePointAt(i))
+                        || uri.charAt(i) == '-' || uri.charAt(i) == '+' || uri.charAt(i) == '.'
+                ) {
+                continue;
+            }
+
+            // a scheme name must be terminated by ';'
+            return uri.charAt(i) == ':';
+        }
+
+        return false;
+    }
+
     public static final boolean isAbsoluteUri(final String uri, final boolean validate) {
 
         // if URI validation is disabled
         if (!validate) {
-            
             // then validate just a scheme
-            for (int i = 0; i < uri.length(); i++) {
-
-                // a scheme name must start with a letter
-                if (i == 0 && Character.isLetter(uri.codePointAt(i))
-                        
-                    // followed by a letter/digit/+/-/. 
-                    || (i > 0 && (
-                            Character.isLetterOrDigit(uri.codePointAt(i))
-                            || uri.charAt(i) == '-' || uri.charAt(i) == '+' || uri.charAt(i) == '.'
-                        ))
-                    ) {
-                    continue;
-                }
-
-                // a scheme name must be terminated by ';'
-                return (i > 0 && uri.charAt(i) == ':');
-            }
-            return false;
+            return startsWithScheme(uri);
         }
 
         try {

--- a/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
@@ -85,10 +85,13 @@ public final class UriUtils {
 
     /**
      * Deprecated in favor of {@link UriUtils#isNotAbsoluteUri(String, boolean)}
+     * 
+     * @deprecated since 1.3.0
+     * 
      * @param uri to check
      * @return <code>true</code> if the given URI is not absolute
      */
-    @Deprecated(since = "1.3.0")
+    @Deprecated
     public static final boolean isNotAbsoluteUri(final String uri) {
         return isNotAbsoluteUri(uri, true);
     }
@@ -99,10 +102,13 @@ public final class UriUtils {
 
     /**
      * Deprecated in favor of {@link UriUtils#isAbsoluteUri(String, boolean)}
+     * 
+     * @deprecated since 1.3.0
+     *
      * @param uri to check
      * @return <code>true</code> if the given URI is absolute
      */
-    @Deprecated(since = "1.3.0")
+    @Deprecated
     public static final boolean isAbsoluteUri(final String uri) {
         return isAbsoluteUri(uri, true);
     }

--- a/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
@@ -42,11 +42,15 @@ public final class UriUtils {
 
         String uriValue = StringUtils.strip(uri);
 
-        if (uri.endsWith(":")) {
-            uriValue = uri + ".";
+        if (uriValue.isEmpty()) {
+            return null;
+        }
 
-        } else if (uri.endsWith("[") || uri.endsWith("]")) {
-            uriValue = uri.substring(0, uri.length() - 1);
+        if (uriValue.endsWith(":")) {
+            uriValue += ".";
+
+        } else if (uriValue.endsWith("[") || uriValue.endsWith("]")) {
+            uriValue = uriValue.substring(0, uriValue.length() - 1);
         }
 
         try {

--- a/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
@@ -114,7 +114,7 @@ public final class UriUtils {
 
     public static final boolean isAbsoluteUri(final String uri, final boolean validate) {
 
-        if (validate) {
+        if (!validate) {
             return uri.indexOf(":") != -1;
         }
         

--- a/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
@@ -94,7 +94,7 @@ public final class UriUtils {
     }
 
     public static final boolean isNotAbsoluteUri(final String uri, final boolean validate) {
-        return !isAbsoluteUri(uri);
+        return !isAbsoluteUri(uri, validate);
     }
 
     /**
@@ -114,6 +114,10 @@ public final class UriUtils {
 
     public static final boolean isAbsoluteUri(final String uri, final boolean validate) {
 
+        if (validate) {
+            return uri.indexOf(":") != -1;
+        }
+        
         try {
             return URI.create(uri).isAbsolute();
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
@@ -108,6 +108,9 @@ public final class UriUtils {
     }
 
     public static final boolean isAbsoluteUri(final String uri, final boolean validate) {
+//        System.out.println("............................ A");
+//        System.out.println("base: " + uri + ", " + validate);
+
 
         // if URI validation is disabled
         if (!validate) {

--- a/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
@@ -85,12 +85,12 @@ public final class UriUtils {
 
     /**
      * Deprecated in favor of {@link UriUtils#isNotAbsoluteUri(String, boolean)}
-     * @param uri
-     * @return
+     * @param uri to check
+     * @return <code>true</code> if the given URI is not absolute
      */
     @Deprecated(since = "1.3.0")
     public static final boolean isNotAbsoluteUri(final String uri) {
-        return !isAbsoluteUri(uri);
+        return isNotAbsoluteUri(uri, true);
     }
 
     public static final boolean isNotAbsoluteUri(final String uri, final boolean validate) {
@@ -99,11 +99,21 @@ public final class UriUtils {
 
     /**
      * Deprecated in favor of {@link UriUtils#isAbsoluteUri(String, boolean)}
-     * @param uri
-     * @return
+     * @param uri to check
+     * @return <code>true</code> if the given URI is absolute
      */
     @Deprecated(since = "1.3.0")
     public static final boolean isAbsoluteUri(final String uri) {
+        return isAbsoluteUri(uri, true);
+    }
+
+    public static final boolean isAbsoluteUri(final String uri, final boolean validate) {
+
+        // if URI validation is disabled
+        if (!validate) {
+            // then validate just a scheme
+            return startsWithScheme(uri);
+        }
 
         try {
             return URI.create(uri).isAbsolute();
@@ -134,23 +144,7 @@ public final class UriUtils {
             // a scheme name must be terminated by ';'
             return uri.charAt(i) == ':';
         }
-
         return false;
-    }
-
-    public static final boolean isAbsoluteUri(final String uri, final boolean validate) {
-
-        // if URI validation is disabled
-        if (!validate) {
-            // then validate just a scheme
-            return startsWithScheme(uri);
-        }
-
-        try {
-            return URI.create(uri).isAbsolute();
-        } catch (IllegalArgumentException e) {
-            return false;
-        }
     }
 
     protected static final String recompose(final String scheme, final String authority, final String path, final String query, final String fragment) {

--- a/src/main/java/com/apicatalog/rdf/Rdf.java
+++ b/src/main/java/com/apicatalog/rdf/Rdf.java
@@ -129,12 +129,12 @@ public final class Rdf {
             throw new IllegalArgumentException();
         }
 
-        if (UriUtils.isAbsoluteUri(value)) {
-            return RdfProvider.provider().createIRI(value);
-        }
-
         if (BlankNode.isWellFormed(value)) {
             return RdfProvider.provider().createBlankNode(value);
+        }
+
+        if (UriUtils.isAbsoluteUri(value, true)) {
+            return RdfProvider.provider().createIRI(value);
         }
 
         return RdfProvider.provider().createTypedString(value, XsdConstants.STRING);
@@ -180,12 +180,12 @@ public final class Rdf {
             throw new IllegalArgumentException("The resource value cannot be null.");
         }
 
-        if (UriUtils.isAbsoluteUri(resource)) {
-            return RdfProvider.provider().createIRI(resource);
-        }
-
         if (BlankNode.isWellFormed(resource)) {
             return RdfProvider.provider().createBlankNode(resource);
+        }
+
+        if (UriUtils.isAbsoluteUri(resource, true)) {
+            return RdfProvider.provider().createIRI(resource);
         }
 
         throw new IllegalArgumentException("The resource must be an absolute IRI or blank node identifier, but was [" + resource + "].");

--- a/src/main/java/com/apicatalog/rdf/io/nquad/NQuadsReader.java
+++ b/src/main/java/com/apicatalog/rdf/io/nquad/NQuadsReader.java
@@ -242,7 +242,7 @@ public final class NQuadsReader implements RdfReader {
     }
 
     private static final void assertAbsoluteIri(final String iri, final String what) throws RdfReaderException {
-        if (UriUtils.isNotAbsoluteUri(iri)) {
+        if (UriUtils.isNotAbsoluteUri(iri, true)) {
             throw new RdfReaderException(what + " must be an absolute IRI [" + iri  +  "]. ");
         }
     }

--- a/src/main/java/com/apicatalog/rdf/lang/XsdConstants.java
+++ b/src/main/java/com/apicatalog/rdf/lang/XsdConstants.java
@@ -24,9 +24,9 @@ public final class XsdConstants {
     public static final String DOUBLE = "http://www.w3.org/2001/XMLSchema#double";
 
     public static final String INTEGER = "http://www.w3.org/2001/XMLSchema#integer";
-    
+
     public static final String INT = "http://www.w3.org/2001/XMLSchema#int";
-    
+
     public static final String LONG = "http://www.w3.org/2001/XMLSchema#long";
 
     private XsdConstants() {

--- a/src/test/java/com/apicatalog/jsonld/http/link/LinkTest.java
+++ b/src/test/java/com/apicatalog/jsonld/http/link/LinkTest.java
@@ -18,6 +18,7 @@ package com.apicatalog.jsonld.http.link;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -158,7 +159,7 @@ class LinkTest {
 
         Link l1 = result.iterator().next();
 
-        assertEquals(URI.create(""), l1.target());
+        assertNull(l1.target());
         assertEquals(Collections.emptySet(), l1.attributes().names());
 
         assertEquals(new HashSet<>(Arrays.asList("123")), l1.relations());
@@ -177,7 +178,7 @@ class LinkTest {
 
         Link l1 = it.next();
 
-        assertEquals(URI.create(""), l1.target());
+        assertNull(l1.target());
         assertEquals(new HashSet<>(Arrays.asList("x")), l1.attributes().names());
 
         assertEquals("x=1x10", l1.attributes().firstValue("x").map(Object::toString).orElse(null));
@@ -322,7 +323,7 @@ class LinkTest {
 
         Link l1 = result.iterator().next();
 
-        assertEquals(URI.create(""), l1.target());
+        assertNull(l1.target());
 
         assertEquals(Arrays.asList(new LinkAttribute("1", "2")), l1.attributes().values());
 
@@ -339,7 +340,7 @@ class LinkTest {
 
         Link l1 = result.iterator().next();
 
-        assertEquals(URI.create(""), l1.target());
+        assertNull(l1.target());
 
         assertEquals(Arrays.asList(new LinkAttribute("1", "23")), l1.attributes().values());
 
@@ -421,7 +422,7 @@ class LinkTest {
 
         Link l1 = it.next();
 
-        assertEquals(URI.create(""), l1.target());
+        assertNull(l1.target());
         assertEquals(new HashSet<>(Arrays.asList("type")), l1.attributes().names());
         assertTrue(l1.attributes().firstValue("type").isPresent());
         assertEquals("text", l1.attributes().firstValue("type").get().value());

--- a/src/test/java/com/apicatalog/jsonld/test/JsonLdTestRunnerJunit.java
+++ b/src/test/java/com/apicatalog/jsonld/test/JsonLdTestRunnerJunit.java
@@ -115,7 +115,7 @@ public class JsonLdTestRunnerJunit {
         }
 
         if (testCase.expectErrorCode != null) {
-            write(testCase, result.getJsonContent().get(), null, null);
+            write(testCase, result.getJsonContent().orElse(null), null, null);
             fail("Expected error [" + testCase.expectErrorCode + "] but got " + result.getContentType() + "].");
             return false;
         }


### PR DESCRIPTION
Adds and option to relax URI validation, if URI validation is disabled then only URIs required for processing are fully parsed and validated.  Might improve performance for huge sets containing a lot of valid URIs.

see `JsonLdOptions.isUriValidation()`