### PR TITLE
Avoid allocation to set frameDefault

### DIFF
--- a/src/main/java/com/apicatalog/jsonld/processor/FramingProcessor.java
+++ b/src/main/java/com/apicatalog/jsonld/processor/FramingProcessor.java
@@ -138,13 +138,13 @@ public final class FramingProcessor {
                                             .create(context, contextBase);
 
         // 13.
-        final List<String> frameKeysExpanded = new ArrayList<>();
-
+        boolean frameDefault = false;
         for (final String key : frameObject.keySet()) {
-            frameKeysExpanded.add(activeContext.uriExpansion().vocab(true).expand(key));
+            if(activeContext.uriExpansion().vocab(true).expand(key).equals(Keywords.GRAPH)) {
+                frameDefault = true;
+                break;
+            }
         }
-
-        boolean frameDefault = frameKeysExpanded.contains(Keywords.GRAPH);
 
         // 14.
         final FramingState state = new FramingState();


### PR DESCRIPTION
Just a little optimization I noticed while reading the code.