### PR TITLE
Use context cache for imported contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ static DocumentLoader LOADER = HttpLoader.defaultInstance().timeount(Duration.of
 JsonLd.expand(...).loader(LOADER).get();
 ```
 
-#### Caching
+#### Document caching
 Configure LRU-based cache for loading documents.
 The argument determines size of the LRU-cache.
 ```javascript
-JsonLd.toRdf("https://example/document.jsonld").loader(new LRUDocumentCache(12)).get();
+JsonLd.toRdf("https://example/document.jsonld").loader(new LRUDocumentCache(loader, 12)).get();
 ```
 
 You can share instance of `LRUDocumentCache` among multiple calls to reuse cached documents.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,19 @@ static DocumentLoader LOADER = HttpLoader.defaultInstance().timeount(Duration.of
 JsonLd.expand(...).loader(LOADER).get();
 ```
 
+#### Caching
+Configure LRU-based cache for loading documents.
+The argument determines size of the LRU-cache.
+```javascript
+JsonLd.toRdf("https://example/document.jsonld").loader(new LRUDocumentCache(12)).get();
+```
+
+You can share instance of `LRUDocumentCache` among multiple calls to reuse cached documents.
+```javascript
+DocumentLoader cachedLoader = new LRUDocumentCache(12);
+JsonLd.toRdf("https://example/document.jsonld").loader(cachedLoader).get();
+JsonLd.toRdf("https://example/another-document.jsonld").loader(cachedLoader).get();
+```
 
 ## Contributing
 

--- a/src/main/java/com/apicatalog/jsonld/context/ActiveContextBuilder.java
+++ b/src/main/java/com/apicatalog/jsonld/context/ActiveContextBuilder.java
@@ -233,27 +233,35 @@ public final class ActiveContextBuilder {
                     throw new JsonLdError(JsonLdErrorCode.LOADING_REMOTE_CONTEXT_FAILED);
                 }
 
-                final DocumentLoaderOptions loaderOptions = new DocumentLoaderOptions();
-                loaderOptions.setProfile(ProfileConstants.CONTEXT);
-                loaderOptions.setRequestProfile(Arrays.asList(loaderOptions.getProfile()));
+                JsonValue importedStructure;
+                final String contextImportUriKey = contextImportUri.toString();
+                if (activeContext.runtime().getContextCache() != null
+                        && activeContext.runtime().getContextCache().containsKey(contextImportUriKey)) {
+                    importedStructure = activeContext.runtime().getContextCache().get(contextImportUriKey);
+                } else {
+                    try {
+                        final DocumentLoaderOptions loaderOptions = new DocumentLoaderOptions();
+                        loaderOptions.setProfile(ProfileConstants.CONTEXT);
+                        loaderOptions.setRequestProfile(Arrays.asList(loaderOptions.getProfile()));
 
-                JsonStructure importedStructure = null;
+                        final Document importedDocument = activeContext.runtime().getDocumentLoader().loadDocument(contextImportUri, loaderOptions);
 
-                try {
+                        if (importedDocument == null) {
+                            throw new JsonLdError(JsonLdErrorCode.INVALID_REMOTE_CONTEXT, "Imported context[" + contextImportUri + "] is null.");
+                        }
 
-                    final Document importedDocument = activeContext.runtime().getDocumentLoader().loadDocument(contextImportUri, loaderOptions);
+                        importedStructure = importedDocument
+                                .getJsonContent()
+                                .orElseThrow(() -> new JsonLdError(JsonLdErrorCode.INVALID_KEYWORD_IMPORT_VALUE));
 
-                    if (importedDocument == null) {
-                        throw new JsonLdError(JsonLdErrorCode.INVALID_REMOTE_CONTEXT, "Imported context[" + contextImportUri + "] is null.");
+                        if (activeContext.runtime().getContextCache() != null) {
+                            activeContext.runtime().getContextCache().put(contextImportUriKey, importedStructure.asJsonObject());
+                        }
+
+                    } catch (JsonLdError e) {
+                        // 5.6.5
+                        throw new JsonLdError(JsonLdErrorCode.INVALID_KEYWORD_IMPORT_VALUE, e);
                     }
-
-                    importedStructure = importedDocument
-                            .getJsonContent()
-                            .orElseThrow(() -> new JsonLdError(JsonLdErrorCode.INVALID_KEYWORD_IMPORT_VALUE));
-
-                    // 5.6.5
-                } catch (JsonLdError e) {
-                    throw new JsonLdError(JsonLdErrorCode.INVALID_KEYWORD_IMPORT_VALUE, e);
                 }
 
                 // 5.6.6

--- a/src/main/java/com/apicatalog/jsonld/context/ActiveContextBuilder.java
+++ b/src/main/java/com/apicatalog/jsonld/context/ActiveContextBuilder.java
@@ -233,35 +233,27 @@ public final class ActiveContextBuilder {
                     throw new JsonLdError(JsonLdErrorCode.LOADING_REMOTE_CONTEXT_FAILED);
                 }
 
-                JsonValue importedStructure;
-                final String contextImportUriKey = contextImportUri.toString();
-                if (activeContext.runtime().getContextCache() != null
-                        && activeContext.runtime().getContextCache().containsKey(contextImportUriKey)) {
-                    importedStructure = activeContext.runtime().getContextCache().get(contextImportUriKey);
-                } else {
-                    try {
-                        final DocumentLoaderOptions loaderOptions = new DocumentLoaderOptions();
-                        loaderOptions.setProfile(ProfileConstants.CONTEXT);
-                        loaderOptions.setRequestProfile(Arrays.asList(loaderOptions.getProfile()));
+                final DocumentLoaderOptions loaderOptions = new DocumentLoaderOptions();
+                loaderOptions.setProfile(ProfileConstants.CONTEXT);
+                loaderOptions.setRequestProfile(Arrays.asList(loaderOptions.getProfile()));
 
-                        final Document importedDocument = activeContext.runtime().getDocumentLoader().loadDocument(contextImportUri, loaderOptions);
+                JsonStructure importedStructure = null;
 
-                        if (importedDocument == null) {
-                            throw new JsonLdError(JsonLdErrorCode.INVALID_REMOTE_CONTEXT, "Imported context[" + contextImportUri + "] is null.");
-                        }
+                try {
 
-                        importedStructure = importedDocument
-                                .getJsonContent()
-                                .orElseThrow(() -> new JsonLdError(JsonLdErrorCode.INVALID_KEYWORD_IMPORT_VALUE));
+                    final Document importedDocument = activeContext.runtime().getDocumentLoader().loadDocument(contextImportUri, loaderOptions);
 
-                        if (activeContext.runtime().getContextCache() != null) {
-                            activeContext.runtime().getContextCache().put(contextImportUriKey, importedStructure.asJsonObject());
-                        }
-
-                    } catch (JsonLdError e) {
-                        // 5.6.5
-                        throw new JsonLdError(JsonLdErrorCode.INVALID_KEYWORD_IMPORT_VALUE, e);
+                    if (importedDocument == null) {
+                        throw new JsonLdError(JsonLdErrorCode.INVALID_REMOTE_CONTEXT, "Imported context[" + contextImportUri + "] is null.");
                     }
+
+                    importedStructure = importedDocument
+                            .getJsonContent()
+                            .orElseThrow(() -> new JsonLdError(JsonLdErrorCode.INVALID_KEYWORD_IMPORT_VALUE));
+
+                    // 5.6.5
+                } catch (JsonLdError e) {
+                    throw new JsonLdError(JsonLdErrorCode.INVALID_KEYWORD_IMPORT_VALUE, e);
                 }
 
                 // 5.6.6

--- a/src/main/java/com/apicatalog/jsonld/loader/DocumentLoaderOptions.java
+++ b/src/main/java/com/apicatalog/jsonld/loader/DocumentLoaderOptions.java
@@ -15,7 +15,6 @@
  */
 package com.apicatalog.jsonld.loader;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Objects;

--- a/src/main/java/com/apicatalog/jsonld/loader/DocumentLoaderOptions.java
+++ b/src/main/java/com/apicatalog/jsonld/loader/DocumentLoaderOptions.java
@@ -15,7 +15,10 @@
  */
 package com.apicatalog.jsonld.loader;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.Objects;
 
 /**
  * The {@link DocumentLoaderOptions} is used to pass various options to the
@@ -62,6 +65,51 @@ public class DocumentLoaderOptions {
 
     public void setRequestProfile(Collection<String> requestProfile) {
         this.requestProfile = requestProfile;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        DocumentLoaderOptions options = (DocumentLoaderOptions) other;
+        if (extractAllScripts != options.extractAllScripts ||
+                !Objects.equals(profile, options.profile)) {
+            return false;
+        }
+        // We need to deal with the collection of profiles.
+        // We assume that the order does matter.
+        if (requestProfile == null && options.requestProfile == null) {
+            // They are bot null.
+            return true;
+        }
+        if (requestProfile == null || options.requestProfile == null) {
+            // Only one is null.
+            return false;
+        }
+        if (requestProfile.size() != options.requestProfile.size()) {
+            // Different size.
+            return false;
+        }
+        // We need to be sure the content is the same.
+        Iterator<String> thisIterator = requestProfile.iterator();
+        Iterator<String> otherIterator = options.requestProfile.iterator();
+        while (thisIterator.hasNext() && otherIterator.hasNext()) {
+            if (!Objects.equals(thisIterator.next(), otherIterator.next())) {
+                // One value is not the same.
+                return false;
+            }
+        }
+        // We have not found a difference thus they are the same.
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(extractAllScripts, profile, requestProfile);
     }
 
 }

--- a/src/main/java/com/apicatalog/jsonld/loader/LRUDocumentCache.java
+++ b/src/main/java/com/apicatalog/jsonld/loader/LRUDocumentCache.java
@@ -5,6 +5,7 @@ import com.apicatalog.jsonld.context.cache.LruCache;
 import com.apicatalog.jsonld.document.Document;
 
 import java.net.URI;
+import java.util.Collection;
 
 public class LRUDocumentCache implements DocumentLoader {
 
@@ -40,7 +41,7 @@ public class LRUDocumentCache implements DocumentLoader {
         // value for objects with same internal values.
         String optionsHash = options.getProfile() + ":" +
                 options.isExtractAllScripts() + ":";
-        var profiles = options.getRequestProfile();
+        Collection<String> profiles = options.getRequestProfile();
         if (profiles == null) {
             optionsHash += "null";
         } else {

--- a/src/main/java/com/apicatalog/jsonld/loader/LRUDocumentCache.java
+++ b/src/main/java/com/apicatalog/jsonld/loader/LRUDocumentCache.java
@@ -1,0 +1,53 @@
+package com.apicatalog.jsonld.loader;
+
+import com.apicatalog.jsonld.JsonLdError;
+import com.apicatalog.jsonld.context.cache.LruCache;
+import com.apicatalog.jsonld.document.Document;
+
+import java.net.URI;
+
+public class LRUDocumentCache implements DocumentLoader {
+
+    private final DocumentLoader documentLoader;
+
+    private final LruCache<String, Document> cache;
+
+    private int counter = 0;
+
+    public LRUDocumentCache(int cacheSize) {
+        this.documentLoader = SchemeRouter.defaultInstance();
+        this.cache = new LruCache<>(cacheSize);
+    }
+
+    public LRUDocumentCache(DocumentLoader documentLoader, int cacheSize) {
+        this.documentLoader = documentLoader;
+        this.cache = new LruCache<>(cacheSize);
+    }
+
+    @Override
+    public Document loadDocument(URI url, DocumentLoaderOptions options) throws JsonLdError {
+        String key = computeCacheKey(url, options);
+        Document result = cache.get(key);
+        if (result == null) {
+            result = documentLoader.loadDocument(url, options);
+            cache.put(key, result);
+        }
+        return result;
+    }
+
+    protected String computeCacheKey(URI url, DocumentLoaderOptions options) {
+        // We can not use options.hashCode() as it does not return same
+        // value for objects with same internal values.
+        String optionsHash = options.getProfile() + ":" +
+                options.isExtractAllScripts() + ":";
+        var profiles = options.getRequestProfile();
+        if (profiles == null) {
+            optionsHash += "null";
+        } else {
+            optionsHash += String.join(",", options.getRequestProfile());
+        }
+        //
+        return url.toString() + ";" + optionsHash;
+    }
+
+}

--- a/src/main/java/com/apicatalog/jsonld/loader/LRUDocumentCache.java
+++ b/src/main/java/com/apicatalog/jsonld/loader/LRUDocumentCache.java
@@ -13,11 +13,6 @@ public class LRUDocumentCache implements DocumentLoader {
 
     private final LruCache<String, Document> cache;
 
-    public LRUDocumentCache(int cacheSize) {
-        this.documentLoader = SchemeRouter.defaultInstance();
-        this.cache = new LruCache<>(cacheSize);
-    }
-
     public LRUDocumentCache(DocumentLoader documentLoader, int cacheSize) {
         this.documentLoader = documentLoader;
         this.cache = new LruCache<>(cacheSize);

--- a/src/main/java/com/apicatalog/jsonld/loader/LRUDocumentCache.java
+++ b/src/main/java/com/apicatalog/jsonld/loader/LRUDocumentCache.java
@@ -9,6 +9,10 @@ import java.util.Objects;
 
 public class LRUDocumentCache implements DocumentLoader {
 
+    private final DocumentLoader documentLoader;
+
+    private final LruCache<Object, Document> cache;
+
     protected static class CacheKey {
 
         private final URI url;
@@ -38,10 +42,6 @@ public class LRUDocumentCache implements DocumentLoader {
             return Objects.hash(url, options);
         }
     }
-
-    private final DocumentLoader documentLoader;
-
-    private final LruCache<Object, Document> cache;
 
     public LRUDocumentCache(DocumentLoader documentLoader, int cacheSize) {
         this.documentLoader = documentLoader;

--- a/src/main/java/com/apicatalog/jsonld/loader/LRUDocumentCache.java
+++ b/src/main/java/com/apicatalog/jsonld/loader/LRUDocumentCache.java
@@ -13,8 +13,6 @@ public class LRUDocumentCache implements DocumentLoader {
 
     private final LruCache<String, Document> cache;
 
-    private int counter = 0;
-
     public LRUDocumentCache(int cacheSize) {
         this.documentLoader = SchemeRouter.defaultInstance();
         this.cache = new LruCache<>(cacheSize);

--- a/src/test/java/com/apicatalog/jsonld/loader/LRUDocumentCacheTest.java
+++ b/src/test/java/com/apicatalog/jsonld/loader/LRUDocumentCacheTest.java
@@ -9,11 +9,16 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 public class LRUDocumentCacheTest {
 
     static class Request {
+
         final URI url;
 
         final DocumentLoaderOptions options;
@@ -99,5 +104,54 @@ public class LRUDocumentCacheTest {
         cachedLoader.loadDocument(URI.create("http://localhost/1"), differentOptions);
         Assertions.assertEquals(2, loader.requests.size());
     }
+
+    @Test
+    void testCachingEqualOptions() throws JsonLdError {
+        RecordRequestLoader loader = new RecordRequestLoader();
+        LRUDocumentCache cachedLoader = new LRUDocumentCache(loader, 2);
+        DocumentLoaderOptions options = null;
+
+        options = new DocumentLoaderOptions();
+        options.setProfile("profile");
+        options.setExtractAllScripts(true);
+        options.setRequestProfile(List.of("first", "second"));
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
+
+        options = new DocumentLoaderOptions();
+        options.setProfile("profile");
+        options.setExtractAllScripts(true);
+        options.setRequestProfile(List.of("first", "second"));
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
+
+        options = new DocumentLoaderOptions();
+        options.setProfile("profile");
+        options.setExtractAllScripts(true);
+        options.setRequestProfile(Arrays.asList("first", "second"));
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
+
+        Assertions.assertEquals(1, loader.requests.size());
+    }
+
+    @Test
+    void testCachingProfilesOrderMatter() throws JsonLdError {
+        RecordRequestLoader loader = new RecordRequestLoader();
+        LRUDocumentCache cachedLoader = new LRUDocumentCache(loader, 2);
+        DocumentLoaderOptions options = null;
+
+        options = new DocumentLoaderOptions();
+        options.setProfile("profile");
+        options.setExtractAllScripts(true);
+        options.setRequestProfile(List.of("first", "second"));
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
+
+        options = new DocumentLoaderOptions();
+        options.setProfile("profile");
+        options.setExtractAllScripts(true);
+        options.setRequestProfile(List.of("second", "first"));
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
+
+        Assertions.assertEquals(2, loader.requests.size());
+    }
+
 
 }

--- a/src/test/java/com/apicatalog/jsonld/loader/LRUDocumentCacheTest.java
+++ b/src/test/java/com/apicatalog/jsonld/loader/LRUDocumentCacheTest.java
@@ -1,0 +1,102 @@
+package com.apicatalog.jsonld.loader;
+
+import com.apicatalog.jsonld.JsonLdError;
+import com.apicatalog.jsonld.document.Document;
+import com.apicatalog.jsonld.document.JsonDocument;
+import jakarta.json.JsonValue;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LRUDocumentCacheTest {
+
+    static class Request {
+        final URI url;
+
+        final DocumentLoaderOptions options;
+
+        public Request(URI url, DocumentLoaderOptions options) {
+            this.url = url;
+            this.options = options;
+        }
+
+    }
+
+    static class DummyLoader implements DocumentLoader {
+
+        public List<Request> requests = new ArrayList<>();
+
+        @Override
+        public Document loadDocument(URI url, DocumentLoaderOptions options) {
+            requests.add(new Request(url, options));
+            // Return empty document.
+            return JsonDocument.of(JsonValue.EMPTY_JSON_ARRAY);
+        }
+
+    }
+
+    @Test
+    void testLoadDocument() throws JsonLdError {
+        DummyLoader dummyLoader = new DummyLoader();
+        LRUDocumentCache cachedLoader = new LRUDocumentCache(dummyLoader, 2);
+
+        DocumentLoaderOptions options = new DocumentLoaderOptions();
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
+
+        // There should be only one call as all other should be cached.
+        Assertions.assertEquals(1, dummyLoader.requests.size());
+        // Make sure valid arguments were passed.
+        Request request = dummyLoader.requests.get(0);
+        Assertions.assertEquals("http://localhost/1",request.url.toString());
+        Assertions.assertSame(options,request.options);
+    }
+
+    @Test
+    void testCacheSize() throws JsonLdError {
+        DummyLoader dummyLoader = new DummyLoader();
+        LRUDocumentCache cachedLoader = new LRUDocumentCache(dummyLoader, 2);
+
+        DocumentLoaderOptions options = new DocumentLoaderOptions();
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
+
+        cachedLoader.loadDocument(URI.create("http://localhost/2"), options);
+        cachedLoader.loadDocument(URI.create("http://localhost/2"), options);
+
+        // There should be only one call as all other should be cached.
+        Assertions.assertEquals(2, dummyLoader.requests.size());
+
+        // Request of new resource.
+        cachedLoader.loadDocument(URI.create("http://localhost/3"), options);
+        Assertions.assertEquals(3, dummyLoader.requests.size());
+
+        // Using LRU the first resources should not be in cache anymore.
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
+        Assertions.assertEquals(4, dummyLoader.requests.size());
+    }
+
+    @Test
+    void testLoadDocumentsWithDifferentOptions() throws JsonLdError {
+        DummyLoader dummyLoader = new DummyLoader();
+        LRUDocumentCache cachedLoader = new LRUDocumentCache(dummyLoader, 2);
+
+        // Using options with same inside should lead to cache hit.
+        DocumentLoaderOptions options = new DocumentLoaderOptions();
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
+        DocumentLoaderOptions sameOptions = new DocumentLoaderOptions();
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), sameOptions);
+        Assertions.assertEquals(1, dummyLoader.requests.size());
+
+        // Use of different options should cause cache miss.
+        DocumentLoaderOptions differentOptions = new DocumentLoaderOptions();
+        differentOptions.setProfile("profile");
+        cachedLoader.loadDocument(URI.create("http://localhost/1"), differentOptions);
+        Assertions.assertEquals(2, dummyLoader.requests.size());
+    }
+
+}

--- a/src/test/java/com/apicatalog/jsonld/loader/LRUDocumentCacheTest.java
+++ b/src/test/java/com/apicatalog/jsonld/loader/LRUDocumentCacheTest.java
@@ -114,19 +114,28 @@ public class LRUDocumentCacheTest {
         options = new DocumentLoaderOptions();
         options.setProfile("profile");
         options.setExtractAllScripts(true);
-        options.setRequestProfile(List.of("first", "second"));
+        List<String> firstList = new ArrayList<>();
+        firstList.add("first");
+        firstList.add("second");
+        options.setRequestProfile(firstList);
         cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
 
         options = new DocumentLoaderOptions();
         options.setProfile("profile");
         options.setExtractAllScripts(true);
-        options.setRequestProfile(List.of("first", "second"));
+        List<String> secondList = new ArrayList<>();
+        secondList.add("first");
+        secondList.add("second");
+        options.setRequestProfile(secondList);
         cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
 
         options = new DocumentLoaderOptions();
         options.setProfile("profile");
         options.setExtractAllScripts(true);
-        options.setRequestProfile(Arrays.asList("first", "second"));
+        List<String> thirdList = new LinkedList<>();
+        thirdList.add("first");
+        thirdList.add("second");
+        options.setRequestProfile(thirdList);
         cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
 
         Assertions.assertEquals(1, loader.requests.size());
@@ -141,13 +150,19 @@ public class LRUDocumentCacheTest {
         options = new DocumentLoaderOptions();
         options.setProfile("profile");
         options.setExtractAllScripts(true);
-        options.setRequestProfile(List.of("first", "second"));
+        List<String> firstList = new ArrayList<>();
+        firstList.add("first");
+        firstList.add("second");
+        options.setRequestProfile(firstList);
         cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
 
         options = new DocumentLoaderOptions();
         options.setProfile("profile");
         options.setExtractAllScripts(true);
-        options.setRequestProfile(List.of("second", "first"));
+        List<String> secondList = new ArrayList<>();
+        secondList.add("second");
+        secondList.add("first");
+        options.setRequestProfile(secondList);
         cachedLoader.loadDocument(URI.create("http://localhost/1"), options);
 
         Assertions.assertEquals(2, loader.requests.size());


### PR DESCRIPTION
Should resolve issue #292, as now the cache is used for imported contexts as well.

In order to work user must set `JsonLdOptions.documentCache` as it is by default null meaning no context caching is applied at all.