### PR TITLE
When there is no uri validation, do not validate the scheme

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.apicatalog</groupId>
         <artifactId>titanium</artifactId>
-        <version>1.4.1</version>
+        <version>1.5.0-SNAPSHOT</version>
         <relativePath>pom_parent.xml</relativePath>
     </parent>
     <artifactId>titanium-json-ld</artifactId>

--- a/pom_jre8.xml
+++ b/pom_jre8.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.apicatalog</groupId>
     <artifactId>titanium</artifactId>
-    <version>1.4.1</version>
+    <version>1.5.0-SNAPSHOT</version>
     <relativePath>pom_parent.xml</relativePath>
   </parent>
   <artifactId>titanium-json-ld-jre8</artifactId>

--- a/pom_parent.xml
+++ b/pom_parent.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.apicatalog</groupId>
   <artifactId>titanium</artifactId>
-  <version>1.4.1</version>
+  <version>1.5.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Titanium JSON-LD 1.1</name>

--- a/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
+++ b/src/main/java/com/apicatalog/jsonld/JsonLdOptions.java
@@ -26,6 +26,7 @@ import com.apicatalog.jsonld.json.JsonProvider;
 import com.apicatalog.jsonld.loader.DocumentLoader;
 import com.apicatalog.jsonld.loader.SchemeRouter;
 
+import com.apicatalog.jsonld.uri.UriValidationPolicy;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 
@@ -57,7 +58,7 @@ public final class JsonLdOptions {
     /* default values */
     public static final boolean DEFAULT_RDF_STAR = false;
     public static final boolean DEFAULT_NUMERIC_ID = false;
-    public static final boolean DEFAULT_URI_VALIDATION = true;
+    public static final UriValidationPolicy DEFAULT_URI_VALIDATION = UriValidationPolicy.Full;
 
     /**
      * The base IRI to use when expanding or compacting the document. If set, this
@@ -132,7 +133,7 @@ public final class JsonLdOptions {
     // document cache
     private Cache<String, Document> documentCache;
 
-    private boolean uriValidation;
+    private UriValidationPolicy uriValidation;
 
     private Duration timeout;
 
@@ -488,9 +489,15 @@ public final class JsonLdOptions {
      * Enabled by default.
      * </p>
      *
-     * @return true if validation is enabled
+     * @deprecated use <code>JsonLdOptions#getUriValidation</code>
+     * @return true if full validation is enabled
      */
+    @Deprecated
     public boolean isUriValidation() {
+        return uriValidation == UriValidationPolicy.Full;
+    }
+
+    public UriValidationPolicy getUriValidation() {
         return uriValidation;
     }
 
@@ -505,10 +512,16 @@ public final class JsonLdOptions {
      * Enabled by default.
      * </p>
      *
+     * @deprecated use <code>JsonLdOptions#setUriValidation(com.apicatalog.jsonld.uri.UriValidationPolicy)</code>
      * @param enabled set <code>true</code> to enable validation
      */
+    @Deprecated
     public void setUriValidation(boolean enabled) {
-        this.uriValidation = enabled;
+        this.uriValidation = UriValidationPolicy.of(enabled);
+    }
+
+    public void setUriValidation(UriValidationPolicy uriValidation) {
+        this.uriValidation = uriValidation;
     }
 
     /**

--- a/src/main/java/com/apicatalog/jsonld/context/ActiveContext.java
+++ b/src/main/java/com/apicatalog/jsonld/context/ActiveContext.java
@@ -160,7 +160,7 @@ public final class ActiveContext {
     }
 
     public UriExpansion uriExpansion() {
-        return UriExpansion.with(this).uriValidation(runtime.isUriValidation());
+        return UriExpansion.with(this).uriValidation(runtime.getUriValidation());
     }
 
     public ValueExpansion valueExpansion() {

--- a/src/main/java/com/apicatalog/jsonld/context/TermDefinitionBuilder.java
+++ b/src/main/java/com/apicatalog/jsonld/context/TermDefinitionBuilder.java
@@ -35,6 +35,7 @@ import com.apicatalog.jsonld.lang.Keywords;
 import com.apicatalog.jsonld.lang.LanguageTag;
 import com.apicatalog.jsonld.uri.UriUtils;
 
+import com.apicatalog.jsonld.uri.UriValidationPolicy;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
@@ -270,7 +271,7 @@ public final class TermDefinitionBuilder {
                     && activeContext.runtime().isV10())
                     // 12.4.
                     || (Keywords.noneMatch(expandedTypeString, Keywords.ID, Keywords.JSON, Keywords.NONE, Keywords.VOCAB)
-                            && UriUtils.isNotAbsoluteUri(expandedTypeString, true))) {
+                            && UriUtils.isNotAbsoluteUri(expandedTypeString, UriValidationPolicy.Full))) {
                 throw new JsonLdError(JsonLdErrorCode.INVALID_TYPE_MAPPING);
             }
 

--- a/src/main/java/com/apicatalog/jsonld/deseralization/JsonLdToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/JsonLdToRdf.java
@@ -29,6 +29,7 @@ import com.apicatalog.jsonld.lang.BlankNode;
 import com.apicatalog.jsonld.lang.Keywords;
 import com.apicatalog.jsonld.lang.Utils;
 import com.apicatalog.jsonld.uri.UriUtils;
+import com.apicatalog.jsonld.uri.UriValidationPolicy;
 import com.apicatalog.rdf.Rdf;
 import com.apicatalog.rdf.RdfDataset;
 import com.apicatalog.rdf.RdfResource;
@@ -50,7 +51,7 @@ public final class JsonLdToRdf {
     // optional
     private boolean produceGeneralizedRdf;
     private RdfDirection rdfDirection;
-    private boolean uriValidation;
+    private UriValidationPolicy uriValidation;
 
     private JsonLdToRdf(NodeMap nodeMap, RdfDataset dataset) {
         this.nodeMap = nodeMap;
@@ -202,7 +203,15 @@ public final class JsonLdToRdf {
         return dataset;
     }
 
+    /**
+     * @deprecated use <code>JsonLdToRdf#uriValidation(com.apicatalog.jsonld.uri.UriValidationPolicy)</code>
+     */
+    @Deprecated
     public JsonLdToRdf uriValidation(boolean uriValidation) {
+        return uriValidation(UriValidationPolicy.of(uriValidation));
+    }
+
+    public JsonLdToRdf uriValidation(UriValidationPolicy uriValidation) {
         this.uriValidation = uriValidation;
         return this;
     }

--- a/src/main/java/com/apicatalog/jsonld/deseralization/ListToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/ListToRdf.java
@@ -24,6 +24,7 @@ import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.JsonLdOptions.RdfDirection;
 import com.apicatalog.jsonld.flattening.NodeMap;
 import com.apicatalog.jsonld.json.JsonUtils;
+import com.apicatalog.jsonld.uri.UriValidationPolicy;
 import com.apicatalog.rdf.Rdf;
 import com.apicatalog.rdf.RdfTriple;
 import com.apicatalog.rdf.RdfValue;
@@ -46,7 +47,7 @@ final class ListToRdf {
 
     // optional
     private RdfDirection rdfDirection;
-    private boolean uriValidation;
+    private UriValidationPolicy uriValidation;
 
     private ListToRdf(final JsonArray list, final List<RdfTriple> triples, NodeMap nodeMap) {
         this.list = list;
@@ -120,7 +121,15 @@ final class ListToRdf {
         return Rdf.createBlankNode(bnodes[0]);
     }
 
+    /**
+     * @deprecated use <code>ListToRdf#uriValidation(com.apicatalog.jsonld.uri.UriValidationPolicy)</code>
+     */
+    @Deprecated
     public ListToRdf uriValidation(boolean uriValidation) {
+        return uriValidation(UriValidationPolicy.of(uriValidation));
+    }
+
+    public ListToRdf uriValidation(UriValidationPolicy uriValidation) {
         this.uriValidation = uriValidation;
         return this;
     }

--- a/src/main/java/com/apicatalog/jsonld/deseralization/ObjectToRdf.java
+++ b/src/main/java/com/apicatalog/jsonld/deseralization/ObjectToRdf.java
@@ -37,6 +37,7 @@ import com.apicatalog.jsonld.lang.ListObject;
 import com.apicatalog.jsonld.lang.NodeObject;
 import com.apicatalog.jsonld.lang.ValueObject;
 import com.apicatalog.jsonld.uri.UriUtils;
+import com.apicatalog.jsonld.uri.UriValidationPolicy;
 import com.apicatalog.rdf.Rdf;
 import com.apicatalog.rdf.RdfLiteral;
 import com.apicatalog.rdf.RdfResource;
@@ -71,7 +72,7 @@ final class ObjectToRdf {
 
     // optional
     private RdfDirection rdfDirection;
-    private boolean uriValidation;
+    private UriValidationPolicy uriValidation;
 
     private ObjectToRdf(JsonObject item, List<RdfTriple> triples, NodeMap nodeMap) {
         this.item = item;
@@ -295,7 +296,15 @@ final class ObjectToRdf {
         return xsdNumberFormat.format(bigDecimal);
     }
 
+    /**
+     * @deprecated use <code>Object#uriValidation(com.apicatalog.jsonld.uri.UriValidationPolicy)</code>
+     */
+    @Deprecated
     public ObjectToRdf uriValidation(boolean uriValidation) {
+        return uriValidation(UriValidationPolicy.of(uriValidation));
+    }
+
+    public ObjectToRdf uriValidation(UriValidationPolicy uriValidation) {
         this.uriValidation = uriValidation;
         return this;
     }

--- a/src/main/java/com/apicatalog/jsonld/expansion/UriExpansion.java
+++ b/src/main/java/com/apicatalog/jsonld/expansion/UriExpansion.java
@@ -30,6 +30,7 @@ import com.apicatalog.jsonld.lang.Keywords;
 import com.apicatalog.jsonld.uri.UriResolver;
 import com.apicatalog.jsonld.uri.UriUtils;
 
+import com.apicatalog.jsonld.uri.UriValidationPolicy;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
 import jakarta.json.JsonValue;
@@ -51,7 +52,7 @@ public final class UriExpansion {
     // optional
     private boolean documentRelative;
     private boolean vocab;
-    private boolean uriValidation;
+    private UriValidationPolicy uriValidation;
 
     private JsonObject localContext;
     private Map<String, Boolean> defined;
@@ -206,7 +207,16 @@ public final class UriExpansion {
         return result;
     }
 
+
+    /**
+     * @deprecated use <code>UriExpansion#uriValidation(com.apicatalog.jsonld.uri.UriValidationPolicy)</code>
+     */
+    @Deprecated
     public UriExpansion uriValidation(boolean uriValidation) {
+        return uriValidation(UriValidationPolicy.of(uriValidation));
+    }
+
+    public UriExpansion uriValidation(UriValidationPolicy uriValidation) {
         this.uriValidation = uriValidation;
         return this;
     }

--- a/src/main/java/com/apicatalog/jsonld/framing/Frame.java
+++ b/src/main/java/com/apicatalog/jsonld/framing/Frame.java
@@ -31,6 +31,7 @@ import com.apicatalog.jsonld.lang.NodeObject;
 import com.apicatalog.jsonld.lang.ValueObject;
 import com.apicatalog.jsonld.uri.UriUtils;
 
+import com.apicatalog.jsonld.uri.UriValidationPolicy;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonString;
@@ -172,9 +173,9 @@ public final class Frame {
                     || idArray
                         .stream()
                         .noneMatch(item -> JsonUtils.isNotString(item)
-                                            || UriUtils.isNotAbsoluteUri(((JsonString)item).getString(), true)));
+                                            || UriUtils.isNotAbsoluteUri(((JsonString)item).getString(), UriValidationPolicy.Full)));
         }
-        return JsonUtils.isString(id) && UriUtils.isAbsoluteUri(((JsonString)id).getString(), true);
+        return JsonUtils.isString(id) && UriUtils.isAbsoluteUri(((JsonString)id).getString(), UriValidationPolicy.Full);
     }
 
     private static final boolean validateFrameType(JsonObject frame) {
@@ -193,12 +194,12 @@ public final class Frame {
                     || typeArray
                         .stream()
                         .noneMatch(item -> JsonUtils.isNotString(item)
-                                            || UriUtils.isNotAbsoluteUri(((JsonString)item).getString(), true)));
+                                            || UriUtils.isNotAbsoluteUri(((JsonString)item).getString(), UriValidationPolicy.Full)));
         }
 
         return JsonUtils.isEmptyArray(type)
                 || JsonUtils.isEmptyObject(type)
-                || JsonUtils.isString(type) && UriUtils.isAbsoluteUri(((JsonString)type).getString(), true);
+                || JsonUtils.isString(type) && UriUtils.isAbsoluteUri(((JsonString)type).getString(), UriValidationPolicy.Full);
     }
 
     public Set<String> keys() {

--- a/src/main/java/com/apicatalog/jsonld/processor/FromRdfProcessor.java
+++ b/src/main/java/com/apicatalog/jsonld/processor/FromRdfProcessor.java
@@ -40,7 +40,7 @@ public final class FromRdfProcessor {
                     .useNativeTypes(options.isUseNativeTypes())
                     .useRdfType(options.isUseRdfType())
                     .processingMode(options.getProcessingMode())
-                    .uriValidation(options.isUriValidation())
+                    .uriValidation(options.getUriValidation())
                     .build();
     }
 

--- a/src/main/java/com/apicatalog/jsonld/processor/ProcessingRuntime.java
+++ b/src/main/java/com/apicatalog/jsonld/processor/ProcessingRuntime.java
@@ -8,6 +8,7 @@ import com.apicatalog.jsonld.context.cache.Cache;
 import com.apicatalog.jsonld.document.Document;
 import com.apicatalog.jsonld.loader.DocumentLoader;
 
+import com.apicatalog.jsonld.uri.UriValidationPolicy;
 import jakarta.json.JsonValue;
 
 /**
@@ -49,8 +50,16 @@ public class ProcessingRuntime {
      */
     public void resetTicker() {/* NOP does nothing if timeout is not set */}
 
+    /**
+     * @deprecated use <code>ProcessingRuntime#getUriValidation()</code>
+     */
+    @Deprecated
     public boolean isUriValidation() {
         return options.isUriValidation();
+    }
+
+    public UriValidationPolicy getUriValidation() {
+        return options.getUriValidation();
     }
 
     public boolean isV10() {

--- a/src/main/java/com/apicatalog/jsonld/processor/ToRdfProcessor.java
+++ b/src/main/java/com/apicatalog/jsonld/processor/ToRdfProcessor.java
@@ -75,7 +75,7 @@ public final class ToRdfProcessor {
                             )
                         .produceGeneralizedRdf(options.isProduceGeneralizedRdf())
                         .rdfDirection(options.getRdfDirection())
-                        .uriValidation(options.isUriValidation())
+                        .uriValidation(options.getUriValidation())
                         .build();
     }
 }

--- a/src/main/java/com/apicatalog/jsonld/serialization/RdfToJsonld.java
+++ b/src/main/java/com/apicatalog/jsonld/serialization/RdfToJsonld.java
@@ -34,6 +34,7 @@ import com.apicatalog.jsonld.lang.Keywords;
 import com.apicatalog.jsonld.lang.LanguageTag;
 import com.apicatalog.jsonld.lang.Utils;
 import com.apicatalog.jsonld.uri.UriUtils;
+import com.apicatalog.jsonld.uri.UriValidationPolicy;
 import com.apicatalog.rdf.RdfDataset;
 import com.apicatalog.rdf.RdfGraph;
 import com.apicatalog.rdf.RdfResource;
@@ -57,7 +58,7 @@ public final class RdfToJsonld {
     private RdfDirection rdfDirection;
     private boolean useNativeTypes;
     private boolean useRdfType;
-    private boolean uriValidation;
+    private UriValidationPolicy uriValidation;
 
     private JsonLdVersion processingMode;
 
@@ -434,7 +435,15 @@ public final class RdfToJsonld {
         private JsonObject value;
     }
 
+    /**
+     * @deprecated use <code>RdfToJsonld#uriValidation(com.apicatalog.jsonld.uri.UriValidationPolicy)</code>
+     */
+    @Deprecated
     public RdfToJsonld uriValidation(boolean uriValidation) {
+        return uriValidation(UriValidationPolicy.of(uriValidation));
+    }
+
+    public RdfToJsonld uriValidation(UriValidationPolicy uriValidation) {
         this.uriValidation = uriValidation;
         return this;
     }

--- a/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
@@ -141,29 +141,27 @@ public final class UriUtils {
     }
 
     public static final boolean isAbsoluteUri(final String uri, final UriValidationPolicy policy) {
-        boolean result = false;
         switch (policy) {
             case None:
-                result = true;
-                break;
+                return true;
             case SchemeOnly:
-                result =  startsWithScheme(uri);
-                break;
+                return startsWithScheme(uri);
             case Full:
                 if (uri == null
                         || uri.length() < 3 // minimal form s(1):ssp(1)
                 ) {
-                    result = false;
+                    return false;
                 } else{
                     try {
-                        result = URI.create(uri).isAbsolute();
+                        return URI.create(uri).isAbsolute();
                     } catch (IllegalArgumentException e) {
-                        result = false;
+                        return false;
                     }
                 }
-                break;
+            default:
+                return false;
         }
-        return result ;
+
     }
 
     private static final boolean startsWithScheme(final String uri) {

--- a/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriUtils.java
@@ -119,7 +119,7 @@ public final class UriUtils {
         // if URI validation is disabled
         if (!validate) {
             // then validate just a scheme
-            return startsWithScheme(uri);
+            return true;
         }
 
         if (uri == null
@@ -133,31 +133,6 @@ public final class UriUtils {
         } catch (IllegalArgumentException e) {
             return false;
         }
-    }
-
-    private static final boolean startsWithScheme(final String uri) {
-
-        if (uri == null
-                || uri.length() < 2 // a scheme must have at least one letter followed by ':'
-                || !Character.isLetter(uri.codePointAt(0)) // a scheme name must start with a letter
-                ) {
-            return false;
-        }
-
-        for (int i = 1; i < uri.length(); i++) {
-
-            if (
-                //  a scheme name must start with a letter followed by a letter/digit/+/-/.
-                Character.isLetterOrDigit(uri.codePointAt(i))
-                        || uri.charAt(i) == '-' || uri.charAt(i) == '+' || uri.charAt(i) == '.'
-                ) {
-                continue;
-            }
-
-            // a scheme name must be terminated by ':'
-            return uri.charAt(i) == ':';
-        }
-        return false;
     }
 
     protected static final String recompose(final String scheme, final String authority, final String path, final String query, final String fragment) {

--- a/src/main/java/com/apicatalog/jsonld/uri/UriValidationPolicy.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriValidationPolicy.java
@@ -21,9 +21,6 @@ public enum UriValidationPolicy {
      * Method allowing to convert the legacy boolean to the matching policy
      */
     public static UriValidationPolicy of(boolean value) {
-        if(value)
-            return Full ;
-        else
-            return SchemeOnly ;
+        return value ? Full : SchemeOnly ;
     }
 }

--- a/src/main/java/com/apicatalog/jsonld/uri/UriValidationPolicy.java
+++ b/src/main/java/com/apicatalog/jsonld/uri/UriValidationPolicy.java
@@ -1,0 +1,29 @@
+package com.apicatalog.jsonld.uri;
+
+public enum UriValidationPolicy {
+
+    /**
+     * No validation is performed
+     */
+    None,
+
+    /**
+     * The validation only targets the scheme
+     */
+    SchemeOnly,
+
+    /**
+     * The validation is be fully performed
+     */
+    Full ;
+
+    /**
+     * Method allowing to convert the legacy boolean to the matching policy
+     */
+    public static UriValidationPolicy of(boolean value) {
+        if(value)
+            return Full ;
+        else
+            return SchemeOnly ;
+    }
+}

--- a/src/main/java/com/apicatalog/rdf/Rdf.java
+++ b/src/main/java/com/apicatalog/rdf/Rdf.java
@@ -27,6 +27,7 @@ import com.apicatalog.jsonld.StringUtils;
 import com.apicatalog.jsonld.http.media.MediaType;
 import com.apicatalog.jsonld.lang.BlankNode;
 import com.apicatalog.jsonld.uri.UriUtils;
+import com.apicatalog.jsonld.uri.UriValidationPolicy;
 import com.apicatalog.rdf.io.RdfReader;
 import com.apicatalog.rdf.io.RdfWriter;
 import com.apicatalog.rdf.io.error.UnsupportedContentException;
@@ -133,7 +134,7 @@ public final class Rdf {
             return RdfProvider.provider().createBlankNode(value);
         }
 
-        if (UriUtils.isAbsoluteUri(value, true)) {
+        if (UriUtils.isAbsoluteUri(value, UriValidationPolicy.Full)) {
             return RdfProvider.provider().createIRI(value);
         }
 
@@ -184,7 +185,7 @@ public final class Rdf {
             return RdfProvider.provider().createBlankNode(resource);
         }
 
-        if (UriUtils.isAbsoluteUri(resource, true)) {
+        if (UriUtils.isAbsoluteUri(resource, UriValidationPolicy.Full)) {
             return RdfProvider.provider().createIRI(resource);
         }
 

--- a/src/main/java/com/apicatalog/rdf/io/nquad/NQuadsReader.java
+++ b/src/main/java/com/apicatalog/rdf/io/nquad/NQuadsReader.java
@@ -19,6 +19,7 @@ import java.io.Reader;
 import java.util.Arrays;
 
 import com.apicatalog.jsonld.uri.UriUtils;
+import com.apicatalog.jsonld.uri.UriValidationPolicy;
 import com.apicatalog.rdf.Rdf;
 import com.apicatalog.rdf.RdfDataset;
 import com.apicatalog.rdf.RdfLiteral;
@@ -242,7 +243,7 @@ public final class NQuadsReader implements RdfReader {
     }
 
     private static final void assertAbsoluteIri(final String iri, final String what) throws RdfReaderException {
-        if (UriUtils.isNotAbsoluteUri(iri, true)) {
+        if (UriUtils.isNotAbsoluteUri(iri, UriValidationPolicy.Full)) {
             throw new RdfReaderException(what + " must be an absolute IRI [" + iri  +  "]. ");
         }
     }

--- a/src/test/java/com/apicatalog/jsonld/api/ToRdfApiTest.java
+++ b/src/test/java/com/apicatalog/jsonld/api/ToRdfApiTest.java
@@ -21,6 +21,7 @@ import com.apicatalog.jsonld.JsonLdOptions;
 import com.apicatalog.jsonld.document.Document;
 import com.apicatalog.jsonld.document.JsonDocument;
 import com.apicatalog.jsonld.http.media.MediaType;
+import com.apicatalog.jsonld.uri.UriValidationPolicy;
 import com.apicatalog.rdf.RdfDataset;
 import com.apicatalog.rdf.RdfNQuad;
 import jakarta.json.JsonValue;
@@ -121,7 +122,7 @@ class ToRdfApiTest {
 
     @Test
     void test12() throws JsonLdError, IOException {
-        RdfDataset result = readRdfDataset(expandedInvalidSubject, false);
+        RdfDataset result = readRdfDataset(expandedInvalidSubject, UriValidationPolicy.None);
 
         boolean includeInvalidSubject = anyInDataset(result, rdfNQuad -> rdfNQuad.getSubject().getValue().equals(invalidUri));
 
@@ -130,7 +131,7 @@ class ToRdfApiTest {
 
     @Test
     void test13() throws JsonLdError, IOException {
-        RdfDataset result = readRdfDataset(expandedInvalidSubject, true);
+        RdfDataset result = readRdfDataset(expandedInvalidSubject, UriValidationPolicy.Full);
 
         boolean includeInvalidSubject = anyInDataset(result, rdfNQuad -> rdfNQuad.getSubject().getValue().equals(invalidUri));
 
@@ -141,7 +142,7 @@ class ToRdfApiTest {
 
     @Test
     void test14() throws JsonLdError, IOException {
-        RdfDataset result = readRdfDataset(expandedInvalidPredicate, false);
+        RdfDataset result = readRdfDataset(expandedInvalidPredicate, UriValidationPolicy.None);
 
         boolean includeInvalidPredicate = anyInDataset(result, rdfNQuad -> rdfNQuad.getPredicate().getValue().equals(invalidUri));
 
@@ -150,7 +151,7 @@ class ToRdfApiTest {
 
     @Test
     void test15() throws JsonLdError, IOException {
-        RdfDataset result = readRdfDataset(expandedInvalidPredicate, true);
+        RdfDataset result = readRdfDataset(expandedInvalidPredicate, UriValidationPolicy.Full);
 
         boolean includeInvalidPredicate = anyInDataset(result, rdfNQuad -> rdfNQuad.getPredicate().getValue().equals(invalidUri));
 
@@ -161,7 +162,7 @@ class ToRdfApiTest {
 
     @Test
     void test16() throws JsonLdError, IOException {
-        RdfDataset result = readRdfDataset(expandedInvalidObject, false);
+        RdfDataset result = readRdfDataset(expandedInvalidObject, UriValidationPolicy.None);
 
         boolean includeInvalidObject = anyInDataset(result, rdfNQuad -> rdfNQuad.getObject().getValue().equals(invalidUri));
 
@@ -170,7 +171,7 @@ class ToRdfApiTest {
 
     @Test
     void test17() throws JsonLdError, IOException {
-        RdfDataset result = readRdfDataset(expandedInvalidObject, true);
+        RdfDataset result = readRdfDataset(expandedInvalidObject, UriValidationPolicy.Full);
 
         boolean includeInvalidObject = anyInDataset(result, rdfNQuad -> rdfNQuad.getObject().getValue().equals(invalidUri));
 
@@ -181,7 +182,7 @@ class ToRdfApiTest {
         return dataset.toList().stream().anyMatch(predicate);
     }
 
-    private RdfDataset readRdfDataset(final String name, final boolean uriValidation) throws JsonLdError, IOException {
+    private RdfDataset readRdfDataset(final String name, final UriValidationPolicy uriValidation) throws JsonLdError, IOException {
         try (final InputStream is = getClass().getResourceAsStream(name)) {
             JsonLdOptions options = new JsonLdOptions();
             options.setUriValidation(uriValidation);

--- a/src/test/resources/com/apicatalog/jsonld/test/issue383-expanded-object.json
+++ b/src/test/resources/com/apicatalog/jsonld/test/issue383-expanded-object.json
@@ -1,0 +1,27 @@
+[
+  {
+    "@id": "http://example.com/john-doe",
+    "@type": [
+      "http://schema.org/Person"
+    ],
+    "http://example.com/address": [
+      {
+        "http://example.com/customid": [
+          {
+            "@id": " http://example.com/invalid"
+          }
+        ],
+        "http://example.com/number": [
+          {
+            "@value": 2
+          }
+        ],
+        "http://example.com/street": [
+          {
+            "@value": "my street"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/test/resources/com/apicatalog/jsonld/test/issue383-expanded-predicate.json
+++ b/src/test/resources/com/apicatalog/jsonld/test/issue383-expanded-predicate.json
@@ -1,0 +1,22 @@
+[
+  {
+    "@id": "http://example.com/john-doe",
+    "@type": [
+      "http://schema.org/Person"
+    ],
+    "http://example.com/address": [
+      {
+        " http://example.com/invalid": [
+          {
+            "@value": 2
+          }
+        ],
+        "http://example.com/street": [
+          {
+            "@value": "my street"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/src/test/resources/com/apicatalog/jsonld/test/issue383-expanded-subject.json
+++ b/src/test/resources/com/apicatalog/jsonld/test/issue383-expanded-subject.json
@@ -1,0 +1,22 @@
+[
+  {
+    "@id": " http://example.com/invalid",
+    "@type": [
+      "http://schema.org/Person"
+    ],
+    "http://example.com/address": [
+      {
+        "http://example.com/number": [
+          {
+            "@value": 2
+          }
+        ],
+        "http://example.com/street": [
+          {
+            "@value": "my street"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Fixes #383

The `RdfDataset` contains the invalid uri even if the scheme is wrong/missing if uri validation is disabled.