### PR TITLE
Make `DefaultHttpLoader` class public

### DIFF
--- a/src/main/java/com/apicatalog/jsonld/loader/DefaultHttpLoader.java
+++ b/src/main/java/com/apicatalog/jsonld/loader/DefaultHttpLoader.java
@@ -36,7 +36,7 @@ import com.apicatalog.jsonld.http.link.Link;
 import com.apicatalog.jsonld.http.media.MediaType;
 import com.apicatalog.jsonld.uri.UriResolver;
 
-class DefaultHttpLoader implements DocumentLoader {
+public class DefaultHttpLoader implements DocumentLoader {
 
     private static final Logger LOGGER = Logger.getLogger(DefaultHttpLoader.class.getName());
 


### PR DESCRIPTION
Otherwise the example from the documentation produces a compilation error:
```java
com.apicatalog.jsonld.loader.DefaultHttpLoader.timeount(java.time.Duration) is defined in an inaccessible class or interface
```