### PR TITLE
Add minimal maven-bundle-plugin config to make titanium-json-ld an OSGi bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,19 @@
                 </includes>
             </configuration>
           </plugin>          
+          <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <version>6.0.2</version>
+            <executions>
+              <execution>
+                <id>bundle</id>
+                <goals>
+                  <goal>bundle</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
     </build>
     


### PR DESCRIPTION
This is a partial fix for https://github.com/filip26/titanium-json-ld/issues/451

This turns titanium-json-ld into an [OSGi bundle](https://en.wikipedia.org/wiki/OSGi#Bundles).

The only effect this PR has is on the MANIFEST.MF of the jar file.

And the MANIFEST.MF headers added by this PR only have effect when loaded into an OSGi execution environment.
