### PR TITLE
Speed up framing for large reference arrays

### DIFF
--- a/src/main/java/com/apicatalog/jsonld/flattening/NodeMap.java
+++ b/src/main/java/com/apicatalog/jsonld/flattening/NodeMap.java
@@ -17,17 +17,22 @@ package com.apicatalog.jsonld.flattening;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import com.apicatalog.jsonld.lang.Keywords;
 
 public final class NodeMap {
 
+    private static final int DUPLICATE_INDEX_THRESHOLD = 32;
+
     private final Map<String, Map<String, Map<String, Object>>> index;
+    private final Map<String, Map<String, Map<String, Set<Object>>>> valueIndex;
 
     private final BlankNodeIdGenerator generator;
 
@@ -38,6 +43,7 @@ public final class NodeMap {
     public NodeMap(BlankNodeIdGenerator generator) {
         this.index = new LinkedHashMap<>();
         this.index.put(Keywords.DEFAULT, new LinkedHashMap<>());
+        this.valueIndex = new LinkedHashMap<>();
         this.generator = generator;
     }
 
@@ -45,6 +51,61 @@ public final class NodeMap {
         index.computeIfAbsent(graphName, x -> new LinkedHashMap<>())
                 .computeIfAbsent(subject, x -> new LinkedHashMap<>())
                 .put(property, value);
+
+        updateExistingValueIndex(graphName, subject, property, value);
+    }
+
+    public boolean appendUnique(String graphName, String subject, String property, Object value) {
+        final var current = get(graphName, subject, property);
+
+        if (current == null) {
+            index.computeIfAbsent(graphName, x -> new LinkedHashMap<>())
+                    .computeIfAbsent(subject, x -> new LinkedHashMap<>())
+                    .put(property, Set.of(value));
+            return true;
+        }
+
+        if (current instanceof Collection<?> collection) {
+
+            if (!hasValueIndex(graphName, subject, property)) {
+                if (collection.contains(value)) {
+                    return false;
+                }
+
+                if (collection.size() < DUPLICATE_INDEX_THRESHOLD) {
+                    return appendValue(graphName, subject, property, current, value);
+                }
+            }
+
+            final var values = valueIndex(graphName, subject, property);
+
+            if (!values.add(value)) {
+                return false;
+            }
+        } else if (current.equals(value)) {
+            return false;
+        }
+
+        return appendValue(graphName, subject, property, current, value);
+    }
+
+    private boolean appendValue(String graphName, String subject, String property, Object current, Object value) {
+        if (current instanceof ArrayList array) {
+            @SuppressWarnings("unchecked")
+            final var typedArray = (List<Object>) array;
+            typedArray.add(value);
+            return true;
+        }
+
+        if (current instanceof Collection<?> collection) {
+            final var updated = new ArrayList<Object>(collection);
+            updated.add(value);
+            index.get(graphName).get(subject).put(property, updated);
+            return true;
+        }
+
+        index.get(graphName).get(subject).put(property, List.of(current, value));
+        return true;
     }
 
     public Optional<Map<String, Map<String, Object>>> find(String graphName) {
@@ -168,6 +229,61 @@ public final class NodeMap {
 
         if (result.index.get(Keywords.MERGED) != null) {
             index.put(Keywords.MERGED, result.index.get(Keywords.MERGED));
+        }
+    }
+
+    private Set<Object> valueIndex(String graphName, String subject, String property) {
+        return valueIndex
+                .computeIfAbsent(graphName, x -> new LinkedHashMap<>())
+                .computeIfAbsent(subject, x -> new LinkedHashMap<>())
+                .computeIfAbsent(property, x -> seedValueIndex(graphName, subject, property));
+    }
+
+    private boolean hasValueIndex(String graphName, String subject, String property) {
+        return Optional.ofNullable(valueIndex.get(graphName))
+                .map(graph -> graph.get(subject))
+                .map(properties -> properties.containsKey(property))
+                .orElse(false);
+    }
+
+    private Set<Object> seedValueIndex(String graphName, String subject, String property) {
+        final var values = new LinkedHashSet<Object>();
+        final var current = get(graphName, subject, property);
+
+        if (current instanceof Collection<?> collection) {
+            values.addAll(collection);
+
+        } else if (current != null) {
+            values.add(current);
+        }
+
+        return values;
+    }
+
+    private void updateExistingValueIndex(String graphName, String subject, String property, Object value) {
+
+        final var graphIndex = valueIndex.get(graphName);
+        if (graphIndex == null) {
+            return;
+        }
+
+        final var subjectIndex = graphIndex.get(subject);
+        if (subjectIndex == null) {
+            return;
+        }
+
+        final var values = subjectIndex.get(property);
+        if (values == null) {
+            return;
+        }
+
+        values.clear();
+
+        if (value instanceof Collection<?> collection) {
+            values.addAll(collection);
+
+        } else if (value != null) {
+            values.add(value);
         }
     }
 }

--- a/src/main/java/com/apicatalog/jsonld/flattening/NodeMapBuilder.java
+++ b/src/main/java/com/apicatalog/jsonld/flattening/NodeMapBuilder.java
@@ -147,45 +147,16 @@ public final class NodeMapBuilder {
             if (list == null) {
 
                 // 4.1.1.
-                final var propertyValue = nodeMap.get(activeGraph, activeSubject, activeProperty);
-
-                if (propertyValue != null) {
-
-                    if (propertyValue instanceof Collection<?> values) {
-
-                        if (values.stream().noneMatch(element::equals)) {
-
-                            if (propertyValue instanceof ArrayList array) {
-                                @SuppressWarnings("unchecked")
-                                var list = (List<Object>) array;
-                                list.add(element);
-
-                            } else {
-                                var list = new ArrayList<Object>(values);
-                                list.add(element);
-                                nodeMap.set(
-                                        activeGraph,
-                                        activeSubject,
-                                        activeProperty,
-                                        list);
-                            }
-                        }
-
-                    } else {
-                        nodeMap.set(
-                                activeGraph,
-                                activeSubject,
-                                activeProperty,
-                                List.of(propertyValue, element));
-                    }
-
-                } else {
+                if (nodeMap.get(activeGraph, activeSubject, activeProperty) == null) {
                     // 4.1.2.
                     nodeMap.set(
                             activeGraph,
                             activeSubject,
                             activeProperty,
                             Set.of(elementMap));
+
+                } else {
+                    nodeMap.appendUnique(activeGraph, activeSubject, activeProperty, element);
                 }
 
             } else {
@@ -272,17 +243,7 @@ public final class NodeMapBuilder {
 
                 // 6.5.1.
                 if (activePropertyValue != null) {
-
-                    if (((Collection<?>) activePropertyValue).stream()
-                            .filter(Map.class::isInstance)
-                            .noneMatch(referencedNode::equals)) {
-
-                        nodeMap.set(
-                                activeGraph,
-                                id,
-                                activeProperty,
-                                append(activePropertyValue, referencedNode));
-                    }
+                    nodeMap.appendUnique(activeGraph, id, activeProperty, referencedNode);
 
                 } else {
                     // 6.5.2.
@@ -302,14 +263,7 @@ public final class NodeMapBuilder {
                     final var activePropertyValue = nodeMap.get(activeGraph, activeSubject, activeProperty);
 
                     if (activePropertyValue != null) {
-
-                        if (((Collection<?>) activePropertyValue).stream().noneMatch(reference::equals)) {
-                            nodeMap.set(
-                                    activeGraph,
-                                    activeSubject,
-                                    activeProperty,
-                                    append(activePropertyValue, reference));
-                        }
+                        nodeMap.appendUnique(activeGraph, activeSubject, activeProperty, reference);
 
                     } else {
                         // 6.6.2.1.

--- a/src/main/java/com/apicatalog/jsonld/framing/Frame.java
+++ b/src/main/java/com/apicatalog/jsonld/framing/Frame.java
@@ -317,14 +317,13 @@ public final class Frame {
 
         if (value instanceof Map map && map.containsKey(Keywords.ID)) {
 
-            final var valueObject = state
-                    .getGraphMap()
-                    .find(state.getGraphName())
-                    .map(graph -> (Map<String, ?>) graph.get((String) map.get(Keywords.ID)));
+            final var valueObject = map.get(Keywords.ID) instanceof String subjectId
+                    ? state.getSubject(subjectId)
+                    : Map.of();
 
-            return valueObject.isPresent()
+            return !valueObject.isEmpty()
                     && FrameMatcher.with(state, this, requireAll)
-                            .match(valueObject.get());
+                            .match(valueObject);
         }
         return false;
     }

--- a/src/main/java/com/apicatalog/jsonld/framing/FrameMatcher.java
+++ b/src/main/java/com/apicatalog/jsonld/framing/FrameMatcher.java
@@ -17,6 +17,7 @@ package com.apicatalog.jsonld.framing;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -49,13 +50,12 @@ public final class FrameMatcher {
             return new ArrayList<>(subjects);
         }
 
+        final var candidates = prefilter(subjects);
         final var result = new ArrayList<String>();
 
-        for (final var subject : subjects) {
+        for (final var subject : candidates) {
 
-            if (match((Map<?, ?>) state.getGraphMap()
-                    .find(state.getGraphName(), subject)
-                    .orElse(Map.of()))) {
+            if (match(state.getSubject(subject))) {
                 result.add(subject);
             }
         }
@@ -78,14 +78,15 @@ public final class FrameMatcher {
 
                 nodeValue = nodeValue instanceof Collection
                         ? nodeValue
-                        : List.of(nodeValue);
+                        : nodeValue != null
+                                ? List.of(nodeValue)
+                                : List.of();
 
                 final var propertyValue = frame.get(property);
 
                 if (propertyValue instanceof Collection<?> array
                         && array.stream().anyMatch(((Collection<?>) nodeValue)::contains)
-                        || frame.isWildCard(Keywords.ID)
-                        || frame.isNone(Keywords.ID)) {
+                        || frame.isWildCard(Keywords.ID)) {
 
                     if (requireAll) {
                         count++;
@@ -284,5 +285,52 @@ public final class FrameMatcher {
         }
 
         return !nonKeywordProperty || count > 0;
+    }
+
+    private Collection<String> prefilter(final Collection<String> subjects) {
+
+        if (subjects.size() <= 1) {
+            return subjects;
+        }
+
+        final var candidates = idCandidates();
+        if (candidates != null) {
+            return filterSubjects(subjects, candidates);
+        }
+
+        return subjects;
+    }
+
+    private Collection<String> idCandidates() {
+        if (!frame.contains(Keywords.ID)
+                || frame.isWildCard(Keywords.ID)
+                || frame.isNone(Keywords.ID)) {
+            return null;
+        }
+
+        final var candidates = new LinkedHashSet<String>();
+
+        for (final var value : frame.asCollection(Keywords.ID)) {
+            if (value instanceof String id) {
+                candidates.add(id);
+            }
+        }
+
+        return candidates;
+    }
+
+    private static Collection<String> filterSubjects(Collection<String> subjects, Collection<String> candidates) {
+        final var candidateSet = candidates instanceof LinkedHashSet<String> linkedHashSet
+                ? linkedHashSet
+                : new LinkedHashSet<>(candidates);
+        final var filtered = new ArrayList<String>(Math.min(subjects.size(), candidates.size()));
+
+        for (final var subject : subjects) {
+            if (candidateSet.contains(subject)) {
+                filtered.add(subject);
+            }
+        }
+
+        return filtered;
     }
 }

--- a/src/main/java/com/apicatalog/jsonld/framing/Framing.java
+++ b/src/main/java/com/apicatalog/jsonld/framing/Framing.java
@@ -16,8 +16,8 @@
 package com.apicatalog.jsonld.framing;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,9 +102,11 @@ public final class Framing {
 
             final var id = ids.next();
 
-            final var node = (Map<String, ?>) state.getGraphMap()
-                    .find(state.getGraphName(), id)
-                    .orElse(Map.of());
+            if (activeProperty == null && !state.isEmbedded()) {
+                state.resetUniqueEmbeds();
+            }
+
+            final var node = state.getSubject(id);
 
             final var nodeId = node.get(Keywords.ID) instanceof String stringNodeId
                     ? stringNodeId
@@ -114,12 +116,8 @@ public final class Framing {
             final var output = new LinkedHashMap<String, Object>();
             output.put(Keywords.ID, id);
 
-            if (activeProperty == null) {
-                state.clearDone();
-            }
-
             // 4.2.
-            if (!state.isEmbedded() && state.isDone(id)) {
+            if (!state.isEmbedded() && state.isEmbedded(id)) {
                 continue;
             }
 
@@ -134,14 +132,12 @@ public final class Framing {
             // 4.4.
             if (state.isEmbedded()
                     && Embed.ONCE == embed
-                    && state.isDone(id)
-
-            ) {
+                    && state.isEmbedded(id)) {
                 addToResult(parent, activeProperty, output);
                 continue;
             }
 
-            state.markDone(id);
+            state.markEmbedded(id);
             state.addParent(nodeId);
 
             // 4.5.
@@ -181,7 +177,6 @@ public final class Framing {
                             graphState,
                             new ArrayList<>(
                                     state.getGraphMap().find(id)
-                                            .or(() -> state.getGraphMap().find(state.getGraphName())) // <— fallback to current graph
                                             .map(Map::keySet)
                                             .orElse(Set.of())),
                             subframe,
@@ -220,6 +215,7 @@ public final class Framing {
                 final var property = properties.next();
 
                 final var objects = state.getGraphMap().get(state.getGraphName(), id, property);
+                final var values = NativeAdapter.asCollection(objects);
 
                 // 4.7.1.
                 if (Keywords.contains(property)) {
@@ -233,7 +229,7 @@ public final class Framing {
                 }
 
                 // 4.7.3.
-                for (final var item : NativeAdapter.asCollection(objects)) {
+                for (final var item : values) {
 
                     var subframe = frame.get(property);
 
@@ -282,7 +278,7 @@ public final class Framing {
 
                                 Framing.with(
                                         listState,
-                                        Arrays.asList(idMap),
+                                        List.of(idMap),
                                         listFrame,
                                         listResult,
                                         Keywords.LIST)
@@ -313,7 +309,7 @@ public final class Framing {
 
                         Framing.with(
                                 clonedState,
-                                Arrays.asList(idMap),
+                                List.of(idMap),
                                 Frame.of(subframe),
                                 output,
                                 property)
@@ -372,9 +368,13 @@ public final class Framing {
 
                 if (reverseObject instanceof Map<?, ?> map) {
 
-                    for (final var reverseEntry : map.entrySet()) {
+                    final var reverseEntries = ordered
+                            ? map.entrySet().stream().sorted(Map.Entry.comparingByKey(Comparator.comparing(String.class::cast))).toList()
+                            : map.entrySet();
 
-                        final Frame subframe = Frame.of(map.get(reverseEntry.getValue()));
+                    for (final var reverseEntry : reverseEntries) {
+
+                        final Frame subframe = Frame.of(reverseEntry.getValue());
 
                         final Set<String> subjectProperties = state.getReversePropertySubjects(state.getGraphName(), (String) reverseEntry.getKey(), id);
 

--- a/src/main/java/com/apicatalog/jsonld/framing/FramingState.java
+++ b/src/main/java/com/apicatalog/jsonld/framing/FramingState.java
@@ -18,6 +18,7 @@ package com.apicatalog.jsonld.framing;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -36,15 +37,17 @@ public final class FramingState {
 
     private NodeMap graphMap;
 
-    private Map<String, Map<String, Boolean>> done;
-
     private Deque<String> parents;
+    private Set<String> parentIndex;
+
+    private Map<String, Set<String>> uniqueEmbeds;
 
     private Map<String, Map<String, Map<String, Set<String>>>> reversePropertyIndex;
 
     public FramingState() {
-        this.done = new HashMap<>();
         this.parents = new ArrayDeque<>();
+        this.parentIndex = new LinkedHashSet<>();
+        this.uniqueEmbeds = new HashMap<>();
     }
 
     public FramingState(FramingState state) {
@@ -55,8 +58,9 @@ public final class FramingState {
         this.omitDefault = state.omitDefault;
         this.graphMap = state.graphMap;
         this.graphName = state.graphName;
-        this.done = state.done;
         this.parents =  state.parents;
+        this.parentIndex = state.parentIndex;
+        this.uniqueEmbeds = state.uniqueEmbeds;
         this.reversePropertyIndex = state.reversePropertyIndex;
     }
 
@@ -116,28 +120,18 @@ public final class FramingState {
         this.graphMap = graphMap;
     }
 
-    public boolean isDone(String subject) {
-        return done.containsKey(graphName) && done.get(graphName).containsKey(subject);
-    }
-
-    public void markDone(String subject) {
-        done.computeIfAbsent(graphName, x -> new HashMap<>()).put(subject, Boolean.TRUE);
-    }
-
     public boolean isParent(String subject) {
-        return parents.contains(graphName + "@@@" +  subject);
+        return parentIndex.contains(parentKey(graphName, subject));
     }
 
     public void addParent(String subject) {
-        parents.push(graphName + "@@@" + subject);
+        final var parentKey = parentKey(graphName, subject);
+        parents.push(parentKey);
+        parentIndex.add(parentKey);
     }
 
     public void removeLastParent() {
-        parents.pop();
-    }
-
-    public void clearDone() {
-        done.clear();
+        parentIndex.remove(parents.pop());
     }
 
     public Set<String> getReversePropertySubjects(String graphName, String property, String value) {
@@ -161,5 +155,30 @@ public final class FramingState {
 
     public void setReversePropertyIndex(Map<String, Map<String, Map<String, Set<String>>>> index) {
         this.reversePropertyIndex = index;
+    }
+
+    public Map<String, ?> getSubject(String subject) {
+        return graphMap.find(graphName, subject).orElse(Map.of());
+    }
+
+    public void resetUniqueEmbeds() {
+        uniqueEmbeds.clear();
+        uniqueEmbeds.computeIfAbsent(graphName, x -> new LinkedHashSet<>());
+    }
+
+    public boolean isEmbedded(String subject) {
+        return uniqueEmbeds
+                .getOrDefault(graphName, Set.of())
+                .contains(subject);
+    }
+
+    public void markEmbedded(String subject) {
+        uniqueEmbeds
+                .computeIfAbsent(graphName, x -> new LinkedHashSet<>())
+                .add(subject);
+    }
+
+    private static String parentKey(String graphName, String subject) {
+        return graphName + "@@@" + subject;
     }
 }

--- a/src/test/java/com/apicatalog/jsonld/custom/FramingLargeReferenceArrayTimeoutTest.java
+++ b/src/test/java/com/apicatalog/jsonld/custom/FramingLargeReferenceArrayTimeoutTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apicatalog.jsonld.custom;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import com.apicatalog.jsonld.JsonLd;
+import com.apicatalog.jsonld.JsonLdException;
+import com.apicatalog.jsonld.Options;
+
+@EnabledIfSystemProperty(named = "titanium.perf.large", matches = "true")
+class FramingLargeReferenceArrayTimeoutTest {
+
+    private static final int ITEM_COUNT = 1_000_000;
+    private static final Duration TIMEOUT = Duration.ofMinutes(1);
+
+    @Test
+    void testLargeReferenceArrayFinishesWithinOneMinute() {
+
+        final var document = buildTestDocument(ITEM_COUNT);
+        final var frame = buildTestFrame();
+        final var elapsedMillis = new AtomicLong();
+
+        assertTimeoutPreemptively(
+                TIMEOUT,
+                () -> {
+                    final long startedAt = System.nanoTime();
+                    final var framed = JsonLd.frame(document, frame, Options.newOptions());
+                    elapsedMillis.set((System.nanoTime() - startedAt) / 1_000_000L);
+                    assertNotNull(framed);
+                });
+
+        System.out.println("Framing %d hub-array items took: %d ms.".formatted(ITEM_COUNT, elapsedMillis.get()));
+    }
+
+    private Map<String, Object> buildTestDocument(final int itemCount) {
+
+        final List<Object> graph = new ArrayList<>(itemCount + 1);
+        final List<Object> contains = new ArrayList<>(itemCount);
+
+        for (int itemIndex = 0; itemIndex < itemCount; itemIndex++) {
+            final String itemId = "http://example.com/item" + itemIndex;
+            contains.add(itemId);
+            graph.add(node(
+                    "@id", itemId,
+                    "@type", "Item"));
+        }
+
+        graph.add(node(
+                "@id", "http://example.com/root",
+                "@type", "Collection",
+                "contains", contains));
+
+        final Map<String, Object> context = node(
+                "@vocab", "http://example.com/vocab#",
+                "contains", node("@type", "@id"));
+
+        return node(
+                "@context", context,
+                "@graph", graph);
+    }
+
+    private Map<String, Object> buildTestFrame() {
+        final Map<String, Object> context = node(
+                "@vocab", "http://example.com/vocab#",
+                "contains", node("@type", "@id"));
+
+        return node(
+                "@context", context,
+                "@type", "Collection",
+                "contains", node(
+                        "@embed", "@once",
+                        "@type", "Item"));
+    }
+
+    private static Map<String, Object> node(Object... entries) {
+        final Map<String, Object> map = new LinkedHashMap<>(entries.length / 2);
+
+        for (int index = 0; index < entries.length; index += 2) {
+            map.put((String) entries[index], entries[index + 1]);
+        }
+
+        return map;
+    }
+}

--- a/src/test/java/com/apicatalog/jsonld/custom/FramingReferenceArrayPerformanceTest.java
+++ b/src/test/java/com/apicatalog/jsonld/custom/FramingReferenceArrayPerformanceTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apicatalog.jsonld.custom;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.apicatalog.jsonld.JsonLd;
+import com.apicatalog.jsonld.JsonLdException;
+import com.apicatalog.jsonld.Options;
+
+class FramingReferenceArrayPerformanceTest {
+
+    @ParameterizedTest(name = "{0} items, {1}")
+    @MethodSource("data")
+    void testFramingReferenceArrays(int itemCount, Duration timeout) throws JsonLdException {
+
+        var data = new TestData(buildTestDocument(itemCount), buildTestFrame());
+
+        assertTimeout(
+                timeout,
+                () -> {
+                    long executionTime = measureFramingPerformance(data);
+                    System.out.println("Framing %d shared-reference items took: %d ms.".formatted(itemCount, executionTime));
+                });
+    }
+
+    static Collection<Object[]> data() {
+        return List.of(
+                new Object[] { 1_000, Duration.ofSeconds(2) },
+                new Object[] { 10_000, Duration.ofSeconds(5) });
+    }
+
+    private long measureFramingPerformance(TestData data) throws JsonLdException {
+
+        long startTime = System.currentTimeMillis();
+
+        var framed = JsonLd.frame(data.document(), data.frame(), Options.newOptions());
+
+        long endTime = System.currentTimeMillis();
+
+        assertNotNull(framed);
+
+        return endTime - startTime;
+    }
+
+    private Map<String, Object> buildTestDocument(int itemCount) {
+
+        List<Object> graph = new ArrayList<>(itemCount + 100);
+        int sharedTagCount = 100;
+        int tagsPerItem = 12;
+
+        for (int tagIndex = 0; tagIndex < sharedTagCount; tagIndex++) {
+            graph.add(node(
+                    "@id", "http://example.com/tag" + tagIndex,
+                    "@type", "Tag",
+                    "name", "Tag " + tagIndex));
+        }
+
+        for (int itemIndex = 0; itemIndex < itemCount; itemIndex++) {
+
+            List<Object> tags = new ArrayList<>(tagsPerItem);
+
+            for (int tagOffset = 0; tagOffset < tagsPerItem; tagOffset++) {
+                tags.add("http://example.com/tag" + ((itemIndex + tagOffset) % sharedTagCount));
+            }
+
+            Map<String, Object> item = node(
+                    "@id", "http://example.com/item" + itemIndex,
+                    "@type", "Item",
+                    "name", "Item " + itemIndex,
+                    "tags", tags);
+
+            if (itemIndex > 0) {
+                item.put("related", "http://example.com/item" + (itemIndex - 1));
+            }
+
+            if (itemIndex + 1 < itemCount) {
+                item.put("next", "http://example.com/item" + (itemIndex + 1));
+            }
+
+            graph.add(item);
+        }
+
+        return node(
+                "@context", node("@vocab", "http://example.com/vocab#"),
+                "@graph", graph);
+    }
+
+    private Map<String, Object> buildTestFrame() {
+        return node(
+                "@context", node("@vocab", "http://example.com/vocab#"),
+                "@type", "Item",
+                "tags", node(
+                        "@embed", "@once",
+                        "@type", "Tag"),
+                "related", node(
+                        "@embed", "@once",
+                        "@type", "Item"),
+                "next", node(
+                        "@embed", "@once",
+                        "@type", "Item"));
+    }
+
+    private static Map<String, Object> node(Object... entries) {
+        Map<String, Object> map = new LinkedHashMap<>(entries.length / 2);
+
+        for (int index = 0; index < entries.length; index += 2) {
+            map.put((String) entries[index], entries[index + 1]);
+        }
+
+        return map;
+    }
+
+    private record TestData(Map<String, Object> document, Map<String, Object> frame) {
+    }
+}


### PR DESCRIPTION
Hi Filip,

As discussed, changes ported to v2. 

This speeds up framing for cases where a document has a very large array of references. The main issue was that we were doing the same linear scans over and over while building the node map and matching frames.
The embed tracking is also closer to how jsonld.js handles this, particularly the per-graph unique embed map and resetting it for each top-level result.

Changes include:

- Add a duplicate-value index for larger node-map property arrays.
- Keep the duplicate index behind a small threshold (`32`) so small arrays stay cheap and simple.

Tested with:
- `mvn test`
- `mvn -Dtest=FramingReferenceArrayPerformanceTest test`
- `mvn -Dtest=FramingLargeReferenceArrayTimeoutTest -Dtitanium.perf.large=true test`

Happy to discuss any change as I'm new to the library!